### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ These arguments are as follows:
 
 1. -Djavacpp.platorm=windows-x86_64 (windows)
 2. -Djavacpp.platform=linux-x86_64
-3. -Djavacpp.platform=mac-osx-x86_64
+3. -Djavacpp.platform=macosx-x86_64
 
 Specifying this can optimize the jar size quite a bit, otherwise
 you end up with extra operating system specific binaries in the jar.


### PR DESCRIPTION
just `mac-osx-x86_64` -> `macosx-x86_64`