### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ model in a deployment. These steps generally include:
 3. Transforming the output in a way that can be understood by humans,
 such as labels in a classification example.
 
-For instance, if you want to run arbitrary Python code for preprocessing purposes,
+For instance, if you want to run arbitrary Python code for pre-processing purposes,
 you can use a`PythonPipelineStep`. To perform inference on a (mix of) TensorFlow,
 Keras, DL4J or PMML models, use `ModelPipelineStep`. Konduit Serving also contains
 functionality for other preprocessing tasks, such as DataVec transform processes,
@@ -27,42 +27,42 @@ or image transforms.
 ## Why Konduit
 
 Konduit was built with the goal of providing proper low level interop
-with native math libraries such as tensorflow and our very own dl4j's
+with native math libraries such as TensorFlow and our very own DL4J's
 core math library libnd4j.
 
-At the core of pipelines are the [javacpp presets](https://github.com/bytedeco/javacpp-presets),
-[vertx](http://vertx.io) and [deeplearning4j](http://deeplearning4j.org)
-for running keras models in java.
+At the core of pipelines are the [JavaCPP Presets](https://github.com/bytedeco/javacpp-presets),
+[vertx](http://vertx.io) and [Deeplearning4j](http://deeplearning4j.org)
+for running Keras models in Java.
 
-Konduit Serving (like some of the other libraries of a similar concept such as [seldon](http://seldon.io/) or [mlflow](http://mlflow.org/))
+Konduit Serving (like some of the other libraries of a similar concept such as [Seldon](http://seldon.io/) or [MLflow](http://mlflow.org/))
 provides building blocks for developers to write their own production
-ML pipelines from pre processing to model serving exposable 
-as a simple rest api.
+ML pipelines from pre-processing to model serving, exposable 
+as a simple REST API.
 
-Combining javacpp's low level access to c like apis from
-java, with java's robust server side application development (vertx on top of [netty](http://netty.io/))
+Combining JavaCPP's low-level access to C-like apis from
+Java, with Java's robust server side application development (vertx on top of [netty](http://netty.io/))
 allows for better access to faster math code in production while minimizing
 the surface area where native code = more security flaws (mainly in server side networked applications)
 
-This allows us to do things like in zero copy memory access of numpy arrays
-or arrow records for consumption straight from the server without copy or serialization overhead.
+This allows us to do things like in zero-copy memory access of NumPy arrays
+or Arrow records for consumption straight from the server without copy or serialization overhead.
 
-When dealing with deep learning, we can handle proper inference on the gpu
+When dealing with deep learning, we can handle proper inference on the GPU
 (batching large workloads)
 
-Extending that to python sdk, we know when to return a raw arrow record and return it as a pandas data frame!
+Extending that to Python SDK, we know when to return a raw Arrow record and return it as a pandas DataFrame!
 
-We also strive to provide a python first sdk that makes it easy to integrate
-pipelines in to a python first workflow.
+We also strive to provide a Python-first SDK that makes it easy to integrate
+pipelines into a Python-first workflow.
 
-Optionally, for the java community a vertx based model server and pipeline development
-framework allow a thin abstraction that is embeddable in a java micro service.
+Optionally, for the Java community, a vertx based model server and pipeline development
+framework allow a thin abstraction that is embeddable in a Java microservice.
 
-Finally, we want to expose [modern standards](http://prometheus.io/) for monitoring everything from your gpu
+Finally, we want to expose [modern standards](http://prometheus.io/) for monitoring everything from your GPU
 to your inference time.
 
-Visualization can happen with applications such as [grafana](http://grafana.com)
-or anything that integrates with the prometheus standard for
+Visualization can happen with applications such as [Grafana](http://grafana.com)
+or anything that integrates with the [Prometheus](https://prometheus.io/) standard for
 visualizing data.
 
 Finally, we aim to provide integrations with more enterprise platforms
@@ -76,66 +76,66 @@ See the `python` subdirectory for our Python SDK.
 
 ## Configuring server on startup
 
-Upon startup, the server loads a config.json or config.yaml file specified by
-the user.  If the user specifies a yaml file it is converted to a config.json
+Upon startup, the server loads a `config.json` or `config.yaml` file specified by
+the user.  If the user specifies a YAML file, it is converted to a `config.json`
 that is then loaded by [vertx](http://vertx.io/).
 
-This gets loaded in to an [InferenceConfiguration](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-api/src/main/java/ai/konduit/serving/InferenceConfiguration.java)
+This gets loaded in to an [InferenceConfiguration](konduit-serving-api/src/main/java/ai/konduit/serving/InferenceConfiguration.java)
 which just contains a list of pipeline steps. Configuring the steps is relative to the implementation.
 
-A small list (but not all!)  of possible implementations can be found [here](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps)
+A small list (but not all!)  of possible implementations can be found [here](konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps).
 
-An individual agent is a java process that gets managed by a [KonduitServerMain](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/KonduitServerMain.java)
+An individual agent is a Java process that gets managed by a [KonduitServingMain](konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/KonduitServingMain.java).
 
-Outside of the pipeline components themselves, the main configuration is a [ServingConfig](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-api/src/main/java/ai/konduit/serving/config/ServingConfig.java)
+Outside of the pipeline components themselves, the main configuration is a [ServingConfig](konduit-serving-api/src/main/java/ai/konduit/serving/config/ServingConfig.java)
 which contains information such as the expected port to start the server on, and the 
-host to listen on (default localhost)
+host to listen on (default localhost).
 
-If you want your model server to listen on the public internet, please use 0.0.0.0
+If you want your model server to listen on the public internet, please use `0.0.0.0`
 instead.
 
-Port configuration varies relative to your type of packaging (for example in docker, it may not matter)
-because the port is already mapped by docker instead.
+Port configuration varies relative to your type of packaging (for example, in Docker, it may not matter)
+because the port is already mapped by Docker instead.
 
 From there, your pipeline may run in to issues such as memory, or warm up issues.
 
-When dealing with either, there are generally a few  considerations:
+When dealing with either, there are generally a few considerations:
 
-1. [Off heap memory in javacpp/dl4j](https://deeplearning4j.org/docs/latest/deeplearning4j-config-memory)
+1. [Off heap memory in JavaCPP/DL4J](https://deeplearning4j.org/docs/latest/deeplearning4j-config-memory)
 
-2. Warmup time for python scripts (sometimes your python script may require warming up the interpreter).
-Summary of this is: depending on what your python script does when running the python server,
+2. Warmup time for Python scripts (sometimes your Python script may require warming up the interpreter).
+Summary of this is: depending on what your Python script does when running the Python server,
 you may want to consider sending a warmup request to your application
 to obtain normal usage.
 
-3. Python path: When using the python step runner, an additional anaconda distribution
-maybe required for custom python script execution. An end to end example can be found in the
-[docker](./docker) directory
+3. Python path: When using the Python step runner, an additional Anaconda distribution
+may be required for custom Python script execution. An end to end example can be found in the
+[docker](./docker) directory.
 
-4. For monitoring, your server has an automatic /metrics endpoint built in
-that is pollable by prometheus or something that can parse the prometheus format.
+4. For monitoring, your server has an automatic `/metrics` endpoint built in
+that is pollable by Prometheus or something that can parse the Prometheus format.
 
-5. A PID file automatically gets written upon startup. Overload the locaion with --pidFile=....
+5. A PID file automatically gets written upon startup. Overload the locaion with `--pidFile=....`.
 
 6. Logging is done via logback. Depending on your application, you may want to over ride how the logging works.
-This can be done by  [over riding the default logback.xml file](https://logback.qos.ch/manual/configuration.html)
+This can be done by [overriding the default `logback.xml` file](https://logback.qos.ch/manual/configuration.html)
 
 7. Configurations can be downloaded from the internet! Vertx supports different ways of configuring
-different configuration providers. Http (without auth) and file are supported by default. For more on this please see
+different configuration providers. HTTP (without auth) and file are supported by default. For more on this, please see
 the [official vertx docs](https://vertx.io/docs/) and bundle your custom configuration provider
 within the built uber jar. If your favorite configuration provider isn't supported,
 please file an issue.
 
 8. Timeouts: Sometimes work execution may take longer. If this is the case,
-please consider looking at the --eventLoopTimeout and --eventLoopExecutionTimeout
+please consider looking at the `--eventLoopTimeout` and `--eventLoopExecutionTimeout`
 arguments.
 
 9. Other vertx arguments: Due to this being a vertx application at its core,
-other vertx jvm arguments will also work. We specify a few that are important
+other vertx JVM arguments will also work. We specify a few that are important
 for our specific application (such as file upload directories for binary files)
 in the KonduitServerMain but allow vertx arguments as well for startup.
 
-For your specific application, consider using the built in monitoring capabilities for both cpu and gpu memory
+For your specific application, consider using the built-in monitoring capabilities for both CPU and GPU memory
 to identify what your ideal pipelines configuration should look like under load.
 
 ### Core workflow:
@@ -143,12 +143,11 @@ to identify what your ideal pipelines configuration should look like under load.
 The core intended workflow is a few simple steps:
 
 1. Configure a server setting up:
-
-      a. `InputType`s of your pipeline
-      b. `OutputType`s of your pipeline
-      c. A `ServingConfiguration` containing things like
+  - `InputType`s of your pipeline
+  - `OutputType`s of your pipeline
+  - A `ServingConfiguration` containing things like
          host and port information
-      d. A series of `PipelineStep`s that represent
+  - A series of `PipelineStep`s that represent
       what steps a deployed pipeline should perform
 
 2. Configure a client to connect to the server.
@@ -157,18 +156,18 @@ The core intended workflow is a few simple steps:
 
 Dependencies:
 
-1. [Jdk 8](https://adoptopenjdk.net/) is preferred.
+1. [JDK 8](https://adoptopenjdk.net/) is preferred.
 2. [mvnw](https://stackoverflow.com/questions/38723833/what-is-the-purpose-of-mvnw-and-mvnw-cmd-files/41239572) will download and setup
-maven automatically 
+Maven automatically 
 
 In order to build pipelines, you need to configure:
 
-1. Chip (-Dchip=YOURCHIP)
-2. OS   (-Djavacpp.platform=YOUR PLATFORM)
-3. Way of packaging (-P<YOUR-PACKAGING>)
-4. Modules to include for your pipeline steps(-P<MODULE-TO-INCLUDE>)
+1. Chip (`-Dchip=YOURCHIP`)
+2. OS   (`-Djavacpp.platform=YOUR PLATFORM`)
+3. Way of packaging (`-P<YOUR-PACKAGING>`)
+4. Modules to include for your pipeline steps(`-P<MODULE-TO-INCLUDE>`)
 
--D is a jvm argument and and -P is a maven profile.
+-D is a JVM argument and and -P is a Maven profile.
 Below we specify the requirements for each configuration.
 
 ### Chips
@@ -194,26 +193,26 @@ Untested but should work (please let us know if you would like to try setting th
 
 Packaging pipelines for a particular operating system typically will depend on
 the target system's supported chips.
-For example, we can target linux with ARM or Intel architecture.
+For example, we can target Linux with ARM or Intel architecture.
 
-Javacpp's platform classifier will also work depending only on the targeted chip.
+JavaCPP's platform classifier will also work depending only on the targeted chip.
 For these concerns, we introduced the -Dchip=gpu/cpu/arm argument
-to the build. This is a thin abstraction over javacpp's packaging
+to the build. This is a thin abstraction over JavaCPP's packaging
 to handle targeting the right platform automatically.
 
 To further thin out other binaries that maybe included (such as opencv)
 we may use -Djavacpp.platform directly. This approach is mainly tested
-with intel chips right now. For other chips, please file an issue.
+with Intel chips right now. For other chips, please file an issue.
 
 These arguments are as follows:
 
-1. -Djavacpp.platorm=windows-x86_64 (windows)
+1. -Djavacpp.platorm=windows-x86_64 (Windows)
 2. -Djavacpp.platform=linux-x86_64
 3. -Djavacpp.platform=mac-osx-x86_64
 
 Specifying this can optimize the jar size quite a bit, otherwise
 you end up with extra operating system specific binaries in the jar.
-Initial feedback via github issues is much appreciated!
+Initial feedback via GitHub Issues is much appreciated!
 
 ### Packaging options
 
@@ -231,7 +230,7 @@ or pipelines bill of materials module.
 
 1. The javacpp.platform jvm argument 
 
-2. The modules included are relative to the [maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html)
+2. The modules included are relative to the [Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html)
 Modules are described below
 
 -  Standard Uberjar: `-Puberjar`
@@ -241,7 +240,7 @@ Modules are described below
 -  WAR file(Java Servlet Application Servers): `-Pwar`
 -  TAR file: `-Ptar`
 -  Kubernetes: See the [helm charts](helm-charts) directory
-for sample charts on building a pipelines module for kubernetes.
+for sample charts on building a pipelines module for Kubernetes.
 
 
 For now, there are no hosted packages beyond what is working in pip at the moment.
@@ -253,8 +252,8 @@ Hosted repositories for the packaging formats listed above will be published lat
 - Python support: `-Ppython`
 - PMML support: `-Ppmml`
 
-In order to configure pipelines for your platform, you use a maven based build profile.
-An example running on cpu:
+In order to configure pipelines for your platform, you use a Maven-based build profile.
+An example running on CPU:
 
 ```bash
 ./mvnw -Ppython -Ppmml -Dchip=cpu -Djavacpp.platform=windows-x86_64 -Puberjar clean install -Dmaven.test.skip=true
@@ -271,14 +270,14 @@ profile, and the output will be found in model-server-uber-jar/target.
 
 ## Custom Pipeline steps
 
-Konduit Serving supports customization via 2 ways: python code or implementing your own
-[PipelineStep](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStep.java)
-via the [CustomPipelineStep](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStep.java)
-and associated [PipelineStepRunner](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps/CustomPipelineStepRunner.java#L40)
-in java.
+Konduit Serving supports customization via 2 ways: Python code or implementing your own
+[PipelineStep](konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStep.java)
+via the [CustomPipelineStep](konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStep.java)
+and associated [PipelineStepRunner](konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps/CustomPipelineStepRunner.java#L40)
+in Java.
 
 Custom pipeline steps are generally recommended for performance reasons.
-Nothing is wrong with starting with just a python step though. Depending on scale,
+Nothing is wrong with starting with just a Python step though. Depending on scale,
 it may not matter.
 
 
@@ -288,20 +287,20 @@ Running multiple versions of a pipelines server with an orchestrations system wi
 etc will heavily rely on vertx functionality. Konduit Serving is fairly small in scope right now.
 
 Vertx has support for many different kinds of typical clustering patterns 
-such as an [api gateway](https://github.com/sczyh30/vertx-blueprint-microservice/blob/master/api-gateway/src/main/java/io/vertx/blueprint/microservice/gateway/APIGatewayVerticle.java), [circuit breaker](https://github.com/vert-x3/vertx-examples/tree/master/circuit-breaker-examples)
+such as an [API gateway](https://github.com/sczyh30/vertx-blueprint-microservice/blob/master/api-gateway/src/main/java/io/vertx/blueprint/microservice/gateway/APIGatewayVerticle.java), [circuit breaker](https://github.com/vert-x3/vertx-examples/tree/master/circuit-breaker-examples)
 
 Depending on what the user is looking to do, we could support some built in patterns in the future
 (for example basic [load balanced pipelines](https://github.com/aesteve/vertx-load-balancer/tree/master/src/main/java/io/vertx/examples/loadbalancer)).
 
 Vertx itself allows for different patterns that could be implemented in either vertx itself
-or in kubernetes.
+or in Kubernetes.
 
 [Cluster management](https://github.com/vert-x3/vertx-awesome#cluster-managers) is also possible
 using one of several cluster node managers allowing a concept of node membership. Communication
 with multiple nodes or processes happens over the [vertx event bus](https://medium.com/@hakdogan/working-with-multiple-verticles-and-communication-between-them-in-vert-x-2ed07e8e6425).
 Examples can be found [here](https://github.com/vert-x3/vertx-examples/tree/master/core-examples/src/main/java/io/vertx/example/core/eventbus) for how to send messages between instances.
 
-A recommended architecture for fault tolerance is to have an api gateway + load balancer
+A recommended architecture for fault tolerance is to have an API gateway + load balancer
 setup with multiple versions of the same pipeline on a named endpoint.
 That named endpoint would represent a load balanced pipeline instance
 where 1 of many pipelines maybe served.
@@ -310,10 +309,10 @@ In a proper cluster, you would address each instance (an InferenceVerticle in th
 as: `/pipeline1/some/inference/endpoint`
 
 For configuration, we recommend versioning all of your assets that are needed alongside
-the config.json in something like a bundle where you can download each versioned asset
+the `config.json` in something like a bundle where you can download each versioned asset
 with its associated configuration and model and start the associated instances from that.
 
-Reference [KonduitServingMain](https://github.com/KonduitAI/konduit-serving/blob/master/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/KonduitServingMain.java)
+Reference [KonduitServingMain](konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/KonduitServingMain.java)
 for an example of the single node use case.
 
 We will add clustering support based on these ideas at a later date. Please file an issue if you have specific questions
@@ -321,4 +320,4 @@ in trying to get a cluster setup.
 
 ## License
 
-Every module in this repo is apache license 2.0, save for `konduit-serving-pmml` which is agpl to comply with the JPMML license.
+Every module in this repo is licensed under the terms of the Apache license 2.0, save for `konduit-serving-pmml` which is agpl to comply with the JPMML license.


### PR DESCRIPTION
Minor fixes, mostly capitalization fixes. 

Also changed URLs linking within the repo to be [relative links](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-readmes).

KonduitServerMain changed to KonduitServingMain due to dead link, I'm not sure if this is correct.