### PR TITLE
pydatavec for examples

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -65,7 +65,7 @@ examples/*.csv
 
 .pytest_cache
 
-# virtual environments
+# Python virtual environments
 venv/
 venv2/
 

--- a/python/konduit/__init__.py
+++ b/python/konduit/__init__.py
@@ -2,8 +2,8 @@ import os
 jar = os.getenv('KONDUIT_JAR_PATH', 'konduit.jar')
 
 try:
-    from jnius_config import set_classpath
-    set_classpath(jar)
+    import pydl4j
+    pydl4j.add_classpath(jar)
 except Exception as e:
     print("VM already running from previous test")
     print(e)

--- a/python/konduit/load.py
+++ b/python/konduit/load.py
@@ -56,14 +56,18 @@ def pop_pid(file_path):
     return pid
 
 
-def load_data(file_path):
+def load_data(file_path, use_yaml=True):
     """Load data from a given YAML file into a Python dictionary.
 
     :param file_path: path to your YAML file.
+    :param use_yaml: use yaml or json
     :return: contents of the file as Python dict.
     """
     with open(file_path, 'r') as f:
-        data = yaml.safe_load(f)
+        if use_yaml:
+            data = yaml.safe_load(f)
+        else:
+            data = json.load(f)
     return data
 
 
@@ -81,24 +85,26 @@ def pop_data(serving_dictionary, dict_key):
     return result
 
 
-def from_file(file_path, start_server=True):
+def from_file(file_path, start_server=True, use_yaml=True):
     """Create Konduit Server and Client from file
 
     :param file_path: path to your konduit.yaml
     :param start_server: whether to start the server instance or not (if not you can start it later).
+    :param use_yaml: use yaml or json
     :return: konduit.server.Server and konduit.client.Client instances
     """
-    return server_from_file(file_path, start_server), client_from_file(file_path)
+    return server_from_file(file_path, start_server, use_yaml), client_from_file(file_path, use_yaml)
 
 
-def server_from_file(file_path, start_server=True):
+def server_from_file(file_path, start_server=True, use_yaml=True):
     """Create a Konduit Server from a from a configuration file.
 
     :param file_path: path to your konduit.yaml
     :param start_server: whether to start the server instance or not (if not you can start it later).
+    :param use_yaml: use yaml or json
     :return: konduit.server.Server instance
     """
-    data = load_data(file_path)
+    data = load_data(file_path, use_yaml)
     serving_data = data.get('serving', None)
 
     extra_start_args = pop_data(serving_data, 'extra_start_args')
@@ -127,13 +133,14 @@ def server_from_file(file_path, start_server=True):
     return server
 
 
-def client_from_file(file_path):
+def client_from_file(file_path, use_yaml=True):
     """Create a Konduit client instance from a configuration file
 
     :param file_path: path to your konduit.yaml
+    :param use_yaml: use yaml or json
     :return: konduit.client.Client instance
     """
-    data = load_data(file_path)
+    data = load_data(file_path, use_yaml)
     client_data = data.get('client', None)
     client = Client(**client_data)
     return client

--- a/python/tests/test_load_yaml.py
+++ b/python/tests/test_load_yaml.py
@@ -25,6 +25,13 @@ def test_yaml_minimal_loading():
     server.stop()
 
 
+def test_json_minimal_loading():
+    file_path = 'yaml/konduit_minimal.json'
+    server = server_from_file(file_path, use_yaml=False)
+    client = client_from_file(file_path, use_yaml=False)
+    server.stop()
+
+
 def test_keras_serving():
     file_path = 'yaml/konduit_keras.yaml'
     server = server_from_file(file_path=file_path)

--- a/python/tests/test_transform_process.py
+++ b/python/tests/test_transform_process.py
@@ -7,15 +7,8 @@ from konduit.utils import is_port_in_use
 import random
 import time
 import json
-from jnius import autoclass
 import pydatavec
-
-
-def load_java_tp(tp_json):
-    """Just used for testing, users won't need this."""
-    StringJava = autoclass("java.lang.String")
-    JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
-    JTransformProcess.fromJson(StringJava(tp_json))
+from .utils import load_java_tp, inference_from_json
 
 
 def test_build_tp():
@@ -27,7 +20,7 @@ def test_build_tp():
 
     tp_json = java_tp.toJson()
     load_java_tp(tp_json)
-    json_tp = json.dumps(tp_json)
+    _ = json.dumps(tp_json)
     as_python_json = json.loads(tp_json)
     transform_process = TransformProcessStep()\
         .set_input(None, ['first'], ['String'])\
@@ -43,9 +36,7 @@ def test_build_tp():
     inference_config = InferenceConfiguration(serving_config=serving_config,
                                               pipeline_steps=[transform_process])
     as_json = config_to_dict_with_type(inference_config)
-    inference_configuration_java_class = autoclass('ai.konduit.serving.InferenceConfiguration')
-    config = inference_configuration_java_class.fromJson(
-        StringJava(json.dumps(as_json)))
+    inference_from_json(as_json)
 
     server = Server(inference_config=inference_config,
                     extra_start_args='-Xmx8g',

--- a/python/tests/test_transform_process.py
+++ b/python/tests/test_transform_process.py
@@ -11,10 +11,14 @@ from jnius import autoclass
 import pydatavec
 
 
-def test_build_tp():
+def load_java_tp(tp_json):
+    """Just used for testing, users won't need this."""
     StringJava = autoclass("java.lang.String")
     JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
+    JTransformProcess.fromJson(StringJava(tp_json))
 
+
+def test_build_tp():
     schema = pydatavec.Schema()
     schema.add_string_column('first')
     tp = pydatavec.TransformProcess(schema)
@@ -22,7 +26,7 @@ def test_build_tp():
     java_tp = tp.to_java()
 
     tp_json = java_tp.toJson()
-    JTransformProcess.fromJson(StringJava(tp_json))
+    load_java_tp(tp_json)
     json_tp = json.dumps(tp_json)
     as_python_json = json.loads(tp_json)
     transform_process = TransformProcessStep()\

--- a/python/tests/test_transform_process.py
+++ b/python/tests/test_transform_process.py
@@ -8,22 +8,22 @@ import random
 import time
 import json
 from jnius import autoclass
+import pydatavec
 
 
 def test_build_tp():
-    TransformProcessBuilder = autoclass(
-        'org.datavec.api.transform.TransformProcess$Builder')
-    TransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
     StringJava = autoclass("java.lang.String")
+    JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
 
-    SchemaBuilder = autoclass(
-        'org.datavec.api.transform.schema.Schema$Builder')
-    schema = SchemaBuilder().addColumnString(StringJava('first')).build()
-    tp = TransformProcessBuilder(schema).appendStringColumnTransform(StringJava("first"), StringJava("two")).build()
+    schema = pydatavec.Schema()
+    schema.add_string_column('first')
+    tp = pydatavec.TransformProcess(schema)
+    tp.append_string('first', 'two')
+    java_tp = tp.to_java()
 
-    tp_json = tp.toJson()
-    TransformProcess.fromJson(StringJava(tp_json))
-    json.dumps(tp_json)
+    tp_json = java_tp.toJson()
+    JTransformProcess.fromJson(StringJava(tp_json))
+    json_tp = json.dumps(tp_json)
     as_python_json = json.loads(tp_json)
     transform_process = TransformProcessStep()\
         .set_input(None, ['first'], ['String'])\
@@ -39,8 +39,7 @@ def test_build_tp():
     inference_config = InferenceConfiguration(serving_config=serving_config,
                                               pipeline_steps=[transform_process])
     as_json = config_to_dict_with_type(inference_config)
-    inference_configuration_java_class = autoclass(
-        'ai.konduit.serving.InferenceConfiguration')
+    inference_configuration_java_class = autoclass('ai.konduit.serving.InferenceConfiguration')
     config = inference_configuration_java_class.fromJson(
         StringJava(json.dumps(as_json)))
 

--- a/python/tests/test_transform_process_arrow.py
+++ b/python/tests/test_transform_process_arrow.py
@@ -8,24 +8,24 @@ import json
 import random
 import time
 from jnius import autoclass
+import pydatavec
 
 
 def test_build_tp():
-    TransformProcessBuilder = autoclass(
-        'org.datavec.api.transform.TransformProcess$Builder')
-    TransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
     StringJava = autoclass("java.lang.String")
-    SchemaBuilder = autoclass(
-        'org.datavec.api.transform.schema.Schema$Builder')
+    JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
 
-    schema = SchemaBuilder().addColumnString(StringJava('first')).build()
-    tp = TransformProcessBuilder(schema) \
-        .appendStringColumnTransform(StringJava("first"), StringJava("two")) \
-        .build()
+    schema = pydatavec.Schema()
+    schema.add_string_column('first')
+    tp = pydatavec.TransformProcess(schema)
+    tp.append_string('first', 'two')
+    java_tp = tp.to_java()
 
-    tp_json = tp.toJson()
-    from_json = TransformProcess.fromJson(StringJava(tp_json))
+    tp_json = java_tp.toJson()
+    JTransformProcess.fromJson(StringJava(tp_json))
+
     json_tp = json.dumps(tp_json)
+
     as_python_json = json.loads(tp_json)
     transform_process = TransformProcessStep()\
         .set_input(None, ['first'], ['String'])\

--- a/python/tests/test_transform_process_arrow.py
+++ b/python/tests/test_transform_process_arrow.py
@@ -11,10 +11,14 @@ from jnius import autoclass
 import pydatavec
 
 
-def test_build_tp():
+def load_java_tp(tp_json):
+    """Just used for testing, users won't need this."""
     StringJava = autoclass("java.lang.String")
     JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
+    JTransformProcess.fromJson(StringJava(tp_json))
 
+
+def test_build_tp():
     schema = pydatavec.Schema()
     schema.add_string_column('first')
     tp = pydatavec.TransformProcess(schema)
@@ -22,8 +26,7 @@ def test_build_tp():
     java_tp = tp.to_java()
 
     tp_json = java_tp.toJson()
-    JTransformProcess.fromJson(StringJava(tp_json))
-
+    load_java_tp(tp_json)
     json_tp = json.dumps(tp_json)
 
     as_python_json = json.loads(tp_json)

--- a/python/tests/test_transform_process_arrow.py
+++ b/python/tests/test_transform_process_arrow.py
@@ -7,15 +7,8 @@ from konduit.utils import is_port_in_use
 import json
 import random
 import time
-from jnius import autoclass
 import pydatavec
-
-
-def load_java_tp(tp_json):
-    """Just used for testing, users won't need this."""
-    StringJava = autoclass("java.lang.String")
-    JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
-    JTransformProcess.fromJson(StringJava(tp_json))
+from .utils import load_java_tp, inference_from_json
 
 
 def test_build_tp():
@@ -27,7 +20,7 @@ def test_build_tp():
 
     tp_json = java_tp.toJson()
     load_java_tp(tp_json)
-    json_tp = json.dumps(tp_json)
+    _ = json.dumps(tp_json)
 
     as_python_json = json.loads(tp_json)
     transform_process = TransformProcessStep()\
@@ -47,11 +40,7 @@ def test_build_tp():
     inference_config = InferenceConfiguration(serving_config=serving_config,
                                               pipeline_steps=[transform_process])
     as_json = config_to_dict_with_type(inference_config)
-    inference_configuration_java = autoclass(
-        'ai.konduit.serving.InferenceConfiguration')
-
-    unused_config = inference_configuration_java.fromJson(
-        StringJava(json.dumps(as_json)))
+    inference_from_json(as_json)
 
     server = Server(inference_config=inference_config,
                     extra_start_args='-Xmx8g',

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -1,0 +1,16 @@
+from jnius import autoclass
+import json
+
+
+def load_java_tp(tp_json):
+    """Just used for testing, users won't need this."""
+    StringJava = autoclass("java.lang.String")
+    JTransformProcess = autoclass('org.datavec.api.transform.TransformProcess')
+    JTransformProcess.fromJson(StringJava(tp_json))
+
+
+def inference_from_json(as_json):
+    StringJava = autoclass("java.lang.String")
+    inference_configuration_java = autoclass('ai.konduit.serving.InferenceConfiguration')
+    inference_configuration_java.fromJson(StringJava(json.dumps(as_json)))
+

--- a/python/tests/yaml/konduit_minimal.json
+++ b/python/tests/yaml/konduit_minimal.json
@@ -1,0 +1,21 @@
+{
+   "serving": {
+      "http_port": 1337
+   },
+   "steps": {
+      "python_step": {
+         "type": "PYTHON",
+         "python_path": ".",
+         "python_code_path": "./simple.py",
+         "python_inputs": {
+            "first": "NDARRAY"
+         },
+         "python_outputs": {
+            "second": "NDARRAY"
+         }
+      }
+   },
+   "client": {
+      "url": "http://localhost:1337"
+   }
+}


### PR DESCRIPTION
This PR is "ready" pending a technical challenge we're facing:

```
test_transform_process_arrow.py:11: in <module>
    import pydatavec
../venv/lib/python3.7/site-packages/pydatavec/__init__.py:20: in <module>
    from .transform_process import *
../venv/lib/python3.7/site-packages/pydatavec/transform_process.py:23: in <module>
    from .java_classes import JString
../venv/lib/python3.7/site-packages/pydatavec/java_classes.py:21: in <module>
    import pydl4j
../venv/lib/python3.7/site-packages/pydl4j-0.1.4-py3.7.egg/pydl4j/__init__.py:1: in <module>
    from .pydl4j import *
../venv/lib/python3.7/site-packages/pydl4j-0.1.4-py3.7.egg/pydl4j/pydl4j.py:347: in <module>
    set_jnius_config()
../venv/lib/python3.7/site-packages/pydl4j-0.1.4-py3.7.egg/pydl4j/pydl4j.py:333: in set_jnius_config
    jnius_config.add_classpath(path)
../venv/lib/python3.7/site-packages/jnius-1.1.0-py3.7-linux-x86_64.egg/jnius_config.py:53: in add_classpath
    raise ValueError("VM is already running, can't set classpath")
E   ValueError: VM is already running, can't set classpath
```

both `konduit` and `pydatavec` compete for setting the classpath from jnius. In this case `konduit` comes first (as it needs its own jar), but then pydatavec complains.