### PR TITLE
Adds support for the image loading step to yaml files.

### DIFF
--- a/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
@@ -384,7 +384,7 @@ public class PipelineRouteDefiner {
 
         });
 
-        router.post("/:inputDataFormat/:predictionType")
+        router.post("/:predictionType/:inputDataFormat")
                 .consumes("multipart/form-data")
                 .consumes("multipart/mixed").handler(ctx -> {
             Map<String, InputAdapter<Buffer, ?>> adapters = getInputAdapterMap(ctx);
@@ -427,8 +427,7 @@ public class PipelineRouteDefiner {
             }, true, result -> ctx.next());
         });
 
-        // TODO: this seems bad for consistency reasons. All routes before flip input and prediction type
-        router.post("/:inputDataFormat/:outputDataFormat")
+        router.post("/:outputDataFormat/:inputDataFormat")
                 .consumes("multipart/form-data")
                 .consumes("multipart/mixed")
                 .produces("application/octet-stream").handler((RoutingContext ctx) -> {

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps/ImageTransformProcessStepRunner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps/ImageTransformProcessStepRunner.java
@@ -71,7 +71,11 @@ public class ImageTransformProcessStepRunner extends BaseStepRunner {
         String inputName = imageLoadingStepConfig.getInputNames().get(inputIndex);
 
         NativeImageLoader nativeImageLoader = imageLoaders.get(inputName);
-        ImageTransformProcess imageTransformProcess = imageLoadingStepConfig.getImageTransformProcesses().get(inputName);
+
+        ImageTransformProcess imageTransformProcess = null;
+        if (imageLoadingStepConfig.getImageTransformProcesses() != null) {
+            imageTransformProcess = imageLoadingStepConfig.getImageTransformProcesses().get(inputName);
+        }
 
         INDArray input;
 

--- a/python/konduit/load.py
+++ b/python/konduit/load.py
@@ -184,6 +184,8 @@ def get_step(step_config):
         step = get_python_step(step_config)
     elif step_type in MODEL_TYPES:
         step = get_model_step(step_config, step_type)
+    elif step_type == 'IMAGE_LOADING':
+        step = get_image_load_step(step_config)
     else:
         raise Exception("Step type of type " + step_type + " currently not supported.")
     return step
@@ -197,6 +199,15 @@ def get_python_step(step_config):
     """
     python_config = PythonConfig(**step_config)
     step = PythonStep().step(python_config)
+    return step
+
+def get_image_load_step(step_config):
+    """Get a ImageLoadingStep from a configuration object
+
+    :param step_config: python dictionary with properties to create the ImageLoadingStep
+    :return: konduit.inference.ImageLoadingStep instance.
+    """
+    step = ImageLoadingStep(**step_config)
     return step
 
 


### PR DESCRIPTION
This code was verified with the code in: https://github.com/wmeddie/konduit-examples/tree/master/pytorch-cifar10-konduit

As per the TODO comment, the route for multipart requests was for some reason backwards compared to the other ones and wasn't consistent with itself, so even reversing the input/output didn't work.  This commit fixes that.