### PR TITLE
Fix build_jar.py (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 ## Overview
 
 Konduit Serving is a serving system and framework focused on deploying machine learning
-konduit-serving to production. The core abstraction is an idea called a "pipeline step".
+pipelines to production. The core abstraction is an idea called a "pipeline step".
 An individual step is meant to perform a task as part of using a machine learning
 model in a deployment scenario. These steps generally include:
 

--- a/build_jar.py
+++ b/build_jar.py
@@ -32,18 +32,18 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--usePython",
-        type=str,
-        default="true",
-        help="whether to bundle python " "or not (typically not encouraged with arm",
-    )
-
-    parser.add_argument(
-        "--usePmml",
-        type=str,
-        default="true",
-        help="whether to use pmml or not,"
-        " not encouraged if agpl license is an issue",
+        "--spin", 
+        type=str, 
+        default="all", 
+        choices=[
+            "minimal", 
+            "python", 
+            "pmml", 
+            "all"
+        ], 
+        help = "whether to bundle Python, PMML, both or neither. Python bundling is\
+         not encouraged with ARM, and PMML bundling is not encouraged if agpl \
+         license is an issue."
     )
 
     parser.add_argument(
@@ -78,10 +78,7 @@ if __name__ == "__main__":
 
     command.append("-Dchip={}".format(arch))
 
-    if strtobool(args.usePython):
-        command.append("-Ppython")
-    if strtobool(args.usePmml):
-        command.append("-Ppmml")
+    command.append("-Dspin.version={}".format(args.spin))
 
     with open(os.path.join(args.source, "pom.xml"), "r") as pom:
         content = pom.read()
@@ -97,11 +94,15 @@ if __name__ == "__main__":
             args.source,
             "konduit-serving-uberjar",
             "target",
-            "konduit-serving-uberjar-{}-custom-{}-{}.jar".format(version[0], args.os, arch),
+            "konduit-serving-uberjar-{}-{}-{}-{}.jar"\
+            .format(version[0], args.spin, args.os, arch),
         ),
         os.path.join(args.source, args.target),
     )
 
     # Copy the built jar file to the "python/tests" folder if it exists.
     if os.path.isdir(os.path.join(args.source, "python", "tests")):
-        copyfile(os.path.join(args.source, args.target), os.path.join(args.source, "python", "tests", "konduit.jar"))
+        copyfile(
+            os.path.join(args.source, args.target), 
+            os.path.join(args.source, "python", "tests", "konduit.jar")
+        )

--- a/build_jar.py
+++ b/build_jar.py
@@ -41,9 +41,9 @@ if __name__ == "__main__":
             "pmml", 
             "all"
         ], 
-        help = "whether to bundle Python, PMML, both or neither. Python bundling is\
-         not encouraged with ARM, and PMML bundling is not encouraged if agpl \
-         license is an issue."
+        help = "whether to bundle Python, PMML, both or neither. Python bundling is" + 
+         "not encouraged with ARM, and PMML bundling is not encouraged if agpl" + 
+         "license is an issue."
     )
 
     parser.add_argument(
@@ -77,6 +77,11 @@ if __name__ == "__main__":
         arch = "cpu"
 
     command.append("-Dchip={}".format(arch))
+
+    if args.spin == "all" or args.spin == "python":
+        command.append("-Ppython")
+    if args.spin == "all" or args.spin == "pmml":
+        command.append("-Ppmml")
 
     command.append("-Dspin.version={}".format(args.spin))
 

--- a/build_jar.py
+++ b/build_jar.py
@@ -70,11 +70,13 @@ if __name__ == "__main__":
     ]
 
     if "arm" in args.os:
-        command.append("-Dchip=arm")
+        arch = "arm"
     elif "gpu" in args.os:
-        command.append("-Dchip=gpu")
+        arch = "gpu"
     else:
-        command.append("-Dchip=cpu")
+        arch = "cpu"
+
+    command.append("-Dchip={}".format(arch))
 
     if strtobool(args.usePython):
         command.append("-Ppython")
@@ -83,7 +85,7 @@ if __name__ == "__main__":
 
     with open(os.path.join(args.source, "pom.xml"), "r") as pom:
         content = pom.read()
-        regex = r"<version>(\d+.\d+.\d+)</version>"
+        regex = r"<version>(\d+.\d+.\d+\S*)</version>"
         version = re.findall(regex, content)
 
     print("Running command: " + " ".join(command))
@@ -95,7 +97,7 @@ if __name__ == "__main__":
             args.source,
             "konduit-serving-uberjar",
             "target",
-            "konduit-serving-uberjar-{}-bin.jar".format(version[0]),
+            "konduit-serving-uberjar-{}-custom-{}-{}.jar".format(version[0], args.os, arch),
         ),
         os.path.join(args.source, args.target),
     )

--- a/python/README.md
+++ b/python/README.md
@@ -26,17 +26,19 @@ called `konduit`. This helper tool can build the Java dependencies needed for `k
 for you under the hood. All you need to do is run:
 
 ```shell script
-konduit init --os <your-platform>
+konduit init --os <your-platform> --spin <spin>
 ```
 
 where `<your-platform>` is picked from `windows-x86_64`,`linux-x86_64`,`linux-x86_64-gpu`,
 `macosx-x86_64`, `linux-armhf` and `windows-x86_64-gpu`, depending on your operating system
-and architecture. This tool assumes that you have `git` installed on your system. If you don't want to use the CLI tool and have cloned this repository, you can also build
+and architecture, and <spin> is picked from `minimal`, `python`, `pmml` and `all`. This tool assumes that you have `git` installed on your system. 
+
+If you don't want to use the CLI tool and have cloned this repository, you can also build
 the necessary jar on your own like this:
 
 ```shell script
 cd ..
-python build_jar.py --os <your-platform>
+python build_jar.py --os <your-platform> --spin <spin>
 ```
 
 ## Using Konduit

--- a/python/cli.py
+++ b/python/cli.py
@@ -39,7 +39,7 @@ def git_clone_konduit(use_https=True):
             )
 
 
-def build_jar(operating_sys):
+def build_jar(operating_sys, spin):
     """Build the actual JAR, using our mvnw wrapper under the hood."""
     if operating_sys is None:
         raise RuntimeError("Specify an operating system to build a konduit jar.")
@@ -60,6 +60,8 @@ def build_jar(operating_sys):
                 operating_sys,
                 "--source",
                 KONDUIT_DIR,
+                "--spin", 
+                spin
             ]
         )
     except Exception as e:
@@ -79,10 +81,18 @@ def build_jar(operating_sys):
     default=True,
     help="If True, use HTTPS to clone konduit-serving, else SSH.",
 )
-def init(os, https):
+@click.option(
+    "--spin",
+    default="all",
+    show_default=True,
+    help="Whether to bundle Python ('python'), PMML ('pmml'), both ('all') " + 
+		 "or neither ('minimal'). Python bundling is not encouraged with ARM, " + 
+		 "and PMML bundling is not encouraged if agpl license is an issue.",
+)
+def init(os, https, spin):
     """Initialize the konduit CLI. You can also use this to build a new konduit-serving JAR."""
     git_clone_konduit(https)
-    build_jar(os)
+    build_jar(os, spin)
 
 
 @click.command()
@@ -92,9 +102,18 @@ def init(os, https):
     help="Your operating system. Choose from  `windows-x86_64`,`linux-x86_64`,"
     "`linux-x86_64-gpu`," + "`macosx-x86_64`, `linux-armhf` and `windows-x86_64-gpu`",
 )
-def build(os):
+@click.option(
+    "--spin",
+    default="all",
+    show_default=True,
+    help="Whether to bundle Python ('python'), PMML ('pmml'), both ('all') " + 
+		 "or neither ('minimal'). Python bundling is not encouraged with ARM, " + 
+		 "and PMML bundling is not encouraged if agpl license is an issue.",
+)
+
+def build(os, spin):
     """Build the underlying konduit.jar (again)."""
-    build_jar(os)
+    build_jar(os, spin)
 
 
 @click.command()


### PR DESCRIPTION
- Allow for non-whitespace characters suffix in version number e.g. 1.0.0"-SNAPSHOT"
- remove -bin suffix from JAR filenames in favour of current JAR filename convention: `konduit-serving-uberjar-{version}-{spin.version}-{os}-{arch}.jar`. Assuming `spin.version` is `custom` here.  

Tested on Windows and Ubuntu.