### PR TITLE
Restore imports in MavenWrapperDownloader class

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Properties;
 
 public class MavenWrapperDownloader {


### PR DESCRIPTION
Also explicitly import required classes. This allows the Maven Wrapper JAR to be downloaded if konduit-serving is built on a Linux system that does not have curl nor wget installed (#181). 

Tested manually by 
- removing maven-wrapper.jar 
- uninstalling curl and wget 
- run `python build_jar.py --os linux-x86_64`