### PR TITLE
Update DEB control file

### DIFF
--- a/konduit-serving-deb/src/deb/control/control
+++ b/konduit-serving-deb/src/deb/control/control
@@ -6,4 +6,5 @@ Architecture: all
 Maintainer: KonduitAI <info@konduit.ai>
 Description: Konduit Serving Package
 Distribution: development
-Depends: git
+Depends: curl, git
+Recommends: openjdk-8-jdk


### PR DESCRIPTION
- RPMs require both curl and git https://github.com/KonduitAI/konduit-serving/blob/f9de6aad810c58e10d824a14f2ab4ae286052b3e/konduit-serving-rpm/pom.xml#L147-L150
Current master doesn't require curl for DEB installs, so adding curl as dependency for DEB builds for parity (may be more appropriate as Build-Depends though). 
- Adding openjdk8 as a recommended install here since user may already have JDK installed e.g. from Oracle (ref https://unix.stackexchange.com/questions/291783/can-i-indicate-that-a-deb-package-depends-on-java-but-not-specify-what-impleme), but not making changes for the RPM build as weak dependencies aren't supported in yum (https://fedoraproject.org/wiki/PackagingDrafts/WeakDependencies)

Tested on Ubuntu