### PR TITLE
Don't force input_name in .step() method to default

### DIFF
--- a/python/konduit/inference.py
+++ b/python/konduit/inference.py
@@ -148,8 +148,8 @@ def python_step_func(
     output_column_names=None,
     output_types=None,
 ):
-    if input_name is None: 
-        raise TypeError("input_name must not be None")
+    if bool(input_name and input_name.strip()): 
+        raise TypeError("input_name must not be None or empty string")
 
     # if nothing else is defined, we can derive all properties just from the Python configuration
     if (
@@ -174,7 +174,6 @@ def python_step_func(
         else:
             output_column_names = list(outputs.keys())
             output_types = [konduit_type_mapping(v) for v in outputs.values()]
-        # if no names are set we default to "default".
 
     self.set_input(
         schema=input_schema,

--- a/python/konduit/inference.py
+++ b/python/konduit/inference.py
@@ -148,7 +148,7 @@ def python_step_func(
     output_column_names=None,
     output_types=None,
 ):
-    if not bool(input_name and input_name.strip()): 
+    if not input_name: 
         raise TypeError("input_name must not be None or empty string")
 
     # if nothing else is defined, we can derive all properties just from the Python configuration

--- a/python/konduit/inference.py
+++ b/python/konduit/inference.py
@@ -148,7 +148,7 @@ def python_step_func(
     output_column_names=None,
     output_types=None,
 ):
-    if bool(input_name and input_name.strip()): 
+    if not bool(input_name and input_name.strip()): 
         raise TypeError("input_name must not be None or empty string")
 
     # if nothing else is defined, we can derive all properties just from the Python configuration

--- a/python/konduit/inference.py
+++ b/python/konduit/inference.py
@@ -148,6 +148,9 @@ def python_step_func(
     output_column_names=None,
     output_types=None,
 ):
+    if input_name is None: 
+        raise TypeError("input_name must not be None")
+
     # if nothing else is defined, we can derive all properties just from the Python configuration
     if (
         input_schema is None
@@ -172,7 +175,6 @@ def python_step_func(
             output_column_names = list(outputs.keys())
             output_types = [konduit_type_mapping(v) for v in outputs.values()]
         # if no names are set we default to "default".
-        input_name = "default"
 
     self.set_input(
         schema=input_schema,


### PR DESCRIPTION
`input_name` default (`"default"`) already set in function signature. We raise `TypeError` if `input_name` is `None`. 