### PR TITLE
Closing of config retriever after successfully obtaining config

### DIFF
--- a/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/KonduitServingMain.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/KonduitServingMain.java
@@ -90,6 +90,8 @@ public class KonduitServingMain {
             if (result.failed()) {
                 log.error("Unable to retrieve configuration " + result.cause());
             } else {
+                configRetriever.close(); // We don't need the config retriever to periodically scan for config after it is successfully retrieved.
+
                 io.vertx.core.json.JsonObject result1 = result.result();
                 konduitServingNodeConfigurer.configureWithJson(result1);
                 vertx.deployVerticle(konduitServingNodeConfigurer.getVerticleClassName(), konduitServingNodeConfigurer.getDeploymentOptions(), handler -> {

--- a/konduit-serving-orchestration/src/main/java/ai/konduit/serving/orchestration/KonduitOrchestrationMain.java
+++ b/konduit-serving-orchestration/src/main/java/ai/konduit/serving/orchestration/KonduitOrchestrationMain.java
@@ -101,6 +101,8 @@ public class KonduitOrchestrationMain {
                                 onFailure.run();
                             }
                         } else {
+                            configRetriever.close(); // We don't need the config retriever to periodically scan for config after it is successfully retrieved.
+
                             try {
                                 Preconditions.checkNotNull(konduitServingNodeConfigurer.getInferenceConfiguration(), "Node configurer inference configuration was null!");
                                 eventBus.request(NODE_COMMUNICATION_TOPIC, new JsonObject(konduitServingNodeConfigurer.getInferenceConfiguration().toJson()), replyHandler -> {


### PR DESCRIPTION
Solving a bug where it still kept looking for config file even after retrieving it successfully. Because of that there were logs of `NoSuchFileException` after the test successfully ran and the config file was deleted in the temporary folder. For reference: https://jenkins.konduit.ai/blue/organizations/jenkins/konduitai%2Fkonduit-serving/detail/master/20/pipeline/153#step-161-log-1725