### PR TITLE
[OLD API] Ability to create CustomStep from python and yaml

### DIFF
--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/CustomStepUDF.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/CustomStepUDF.java
@@ -22,14 +22,14 @@
 
 package ai.konduit.serving.pipeline;
 
-import ai.konduit.serving.pipeline.step.CustomPipelineStep;
+import ai.konduit.serving.pipeline.step.CustomStep;
 import org.datavec.api.records.Record;
 
 /**
  * A user defined function for use with the
- * {@link CustomPipelineStep}. This is where
+ * {@link CustomStep}. This is where
  * a user defines an extension for use within a
- * {@link CustomPipelineStep}.
+ * {@link CustomStep}.
  * <p>
  * A user defined function should take in an
  * array of {@link Record} and output an array of {@link Record}
@@ -41,12 +41,12 @@ import org.datavec.api.records.Record;
  *
  * @author Adam Gibson
  */
-public interface CustomPipelineStepUDF {
+public interface CustomStepUDF {
 
 
     /**
      * The user defined function where a user can define custom behavior
-     * for a {@link CustomPipelineStep}
+     * for a {@link CustomStep}
      *
      * @param input the input records (generally 1 record per input name for the pipeline step)
      * @return the output records (generally 1 record per output name for the pipeline step)

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStep.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStep.java
@@ -1,18 +1,18 @@
 package ai.konduit.serving.pipeline;
 
-import  java.io.Serializable;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import ai.konduit.serving.config.Input;
 import ai.konduit.serving.config.Output;
 import ai.konduit.serving.config.Output.PredictionType;
+import ai.konduit.serving.config.SchemaType;
+import ai.konduit.serving.pipeline.step.*;
+import org.datavec.api.transform.schema.Schema;
 import org.nd4j.shade.jackson.annotation.JsonSubTypes;
 import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
-import ai.konduit.serving.pipeline.step.*;
-import ai.konduit.serving.config.SchemaType;
-import org.datavec.api.transform.schema.Schema;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.nd4j.shade.jackson.annotation.JsonTypeInfo.As.PROPERTY;
 import static org.nd4j.shade.jackson.annotation.JsonTypeInfo.Id.NAME;
@@ -30,7 +30,7 @@ import static org.nd4j.shade.jackson.annotation.JsonTypeInfo.Id.NAME;
         @JsonSubTypes.Type(value = PythonStep.class, name = "PythonStep"),
         @JsonSubTypes.Type(value = PmmlStep.class, name = "PmmlStep"),
         @JsonSubTypes.Type(value = TransformProcessStep.class, name = "TransformProcessStep"),
-        @JsonSubTypes.Type(value = CustomPipelineStep.class, name = "CustomPipelineStep"),
+        @JsonSubTypes.Type(value = CustomStep.class, name = "CustomStep"),
         @JsonSubTypes.Type(value = ImageLoadingStep.class, name = "ImageLoadingStep"),
         @JsonSubTypes.Type(value = JsonExpanderTransformStep.class, name = "JsonExpanderTransformStep"),
         @JsonSubTypes.Type(value = ArrayConcatenationStep.class, name = "ArrayConcatenationStep"),

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStepRunner.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/PipelineStepRunner.java
@@ -23,7 +23,7 @@
 package ai.konduit.serving.pipeline;
 
 import ai.konduit.serving.config.SchemaType;
-import ai.konduit.serving.pipeline.step.CustomPipelineStep;
+import ai.konduit.serving.pipeline.step.CustomStep;
 import org.datavec.api.records.Record;
 import org.datavec.api.writable.Writable;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -45,7 +45,7 @@ import java.util.Map;
  * {@link Record} and returns 1 or more output {@link Record}.
  * <p>
  * There are a  number of implementations. You can also create a custom one
- * using the {@link CustomPipelineStep} and {@link CustomPipelineStepUDF}
+ * using the {@link CustomStep} and {@link CustomStepUDF}
  * definitions. This is recommended as the easiest way of creating your own custom ones.
  * Otherwise, we try to provide any number of off the shelf ones
  * for running python scripts or machine learning models.

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/step/CustomStep.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/step/CustomStep.java
@@ -30,7 +30,7 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-public class CustomPipelineStep extends BasePipelineStep<CustomPipelineStep> {
+public class CustomStep extends BasePipelineStep<CustomStep> {
 
     private String customUdfClazz;
 

--- a/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
+++ b/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
@@ -107,7 +107,7 @@ public class CodeGen {
             ObjectNode objectNode = (ObjectNode) jsonNode;
             objectNode.putObject("definitions");
             objectNode.put("title",clazz.getSimpleName());
-            File classJson = new File("schema-%s.json", clazz.getSimpleName());
+            File classJson = new File(String.format("schema-%s.json", clazz.getSimpleName()));
             if(classJson.exists()) {
                 boolean deleted = classJson.delete();
                 System.out.println(deleted);

--- a/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
+++ b/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
@@ -83,6 +83,7 @@ public class CodeGen {
                 ArrayConcatenationStep.class,
                 JsonExpanderTransformStep.class,
                 ImageLoadingStep.class,
+                CustomStep.class,
                 MemMapConfig.class,
                 InferenceConfiguration.class,
         };

--- a/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
+++ b/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
@@ -198,7 +198,7 @@ public class CodeGen {
         FileUtils.writeStringToFile(newModule, sb,Charset.defaultCharset(),false);
 
         Process autopepLinting = runtime.exec("autopep8 --in-place " + newModule);
-        autopepLinting.waitFor(8, TimeUnit.SECONDS);
+        autopepLinting.waitFor(12, TimeUnit.SECONDS);
         if(autopepLinting.exitValue() != 0) {
             String errorMessage = "";
             try(InputStream is = autopepLinting.getInputStream()) {

--- a/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/PythonDocStrings.java
+++ b/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/PythonDocStrings.java
@@ -203,8 +203,6 @@ public class PythonDocStrings {
                         "    code either as string to `python_code` or as path to a Python script to `python_code_path`.\n" +
                         "    Additionally, you can modify or extend your Python path by setting `python_path` accordingly.\n" +
                         "\n" +
-                        "    :param tensor_data_types_config: konduit.TensorDataTypesConfig\n" +
-                        "    :param model_config_type: konduit.ModelConfigType\n" +
                         "    :param python_code: Python code as str\n" +
                         "    :param python_code_path: full qualifying path to the Python script you want to run, as str\n" +
                         "    :param python_inputs: list of Python input variable names\n" +

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps/CustomStepRunner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/pipeline/steps/CustomStepRunner.java
@@ -22,9 +22,9 @@
 
 package ai.konduit.serving.pipeline.steps;
 
-import ai.konduit.serving.pipeline.CustomPipelineStepUDF;
+import ai.konduit.serving.pipeline.CustomStepUDF;
 import ai.konduit.serving.pipeline.BasePipelineStep;
-import ai.konduit.serving.pipeline.step.CustomPipelineStep;
+import ai.konduit.serving.pipeline.step.CustomStep;
 import org.datavec.api.records.Record;
 import org.datavec.api.writable.Writable;
 
@@ -34,13 +34,13 @@ import static java.lang.Class.forName;
 
 public class CustomStepRunner extends BaseStepRunner {
 
-    private CustomPipelineStepUDF customPipelineStepUDF;
+    private CustomStepUDF customStepUDF;
 
     public CustomStepRunner(BasePipelineStep pipelineStep) {
         super(pipelineStep);
-        CustomPipelineStep customPipelineStep = (CustomPipelineStep) pipelineStep;
+        CustomStep customStep = (CustomStep) pipelineStep;
         try {
-            this.customPipelineStepUDF = (CustomPipelineStepUDF) forName(customPipelineStep.getCustomUdfClazz()).newInstance();
+            this.customStepUDF = (CustomStepUDF) forName(customStep.getCustomUdfClazz()).newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -48,7 +48,7 @@ public class CustomStepRunner extends BaseStepRunner {
 
     @Override
     public Record[] transform(Record[] input) {
-        return customPipelineStepUDF.udf(input);
+        return customStepUDF.udf(input);
     }
 
     @Override

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/inference/PipelineTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/inference/PipelineTests.java
@@ -27,7 +27,6 @@ import ai.konduit.serving.pipeline.PmmlInferenceExecutionerStepRunner;
 import ai.konduit.serving.pipeline.step.*;
 import ai.konduit.serving.pipeline.steps.*;
 import ai.konduit.serving.util.SchemaTypeUtils;
-import org.bytedeco.tensorflow.Mod;
 import org.datavec.api.records.Record;
 import org.datavec.api.transform.MathOp;
 import org.datavec.api.transform.TransformProcess;
@@ -128,7 +127,7 @@ public class PipelineTests {
         ArrayConcatenationStep arrayConcatStep = ArrayConcatenationStep.builder().build();
         assertEquals(ArrayConcatenationStepRunner.class.getName(), arrayConcatStep.pipelineStepClazz());
 
-        CustomPipelineStep customStep = CustomPipelineStep.builder().build();
+        CustomStep customStep = CustomStep.builder().build();
         assertEquals(CustomStepRunner.class.getName(), customStep.pipelineStepClazz());
 
         JsonExpanderTransformStep jsonStep = JsonExpanderTransformStep.builder().build();

--- a/python/konduit/base_inference.py
+++ b/python/konduit/base_inference.py
@@ -935,8 +935,6 @@ class PythonConfig(object):
     code either as string to `python_code` or as path to a Python script to `python_code_path`.
     Additionally, you can modify or extend your Python path by setting `python_path` accordingly.
 
-    :param tensor_data_types_config: konduit.TensorDataTypesConfig
-    :param model_config_type: konduit.ModelConfigType
     :param python_code: Python code as str
     :param python_code_path: full qualifying path to the Python script you want to run, as str
     :param python_inputs: list of Python input variable names
@@ -948,8 +946,6 @@ class PythonConfig(object):
     """
 
     _types_map = {
-        "tensorDataTypesConfig": {"type": TensorDataTypesConfig, "subtype": None},
-        "modelConfigType": {"type": ModelConfigType, "subtype": None},
         "pythonCode": {"type": str, "subtype": None},
         "pythonCodePath": {"type": str, "subtype": None},
         "pythonPath": {"type": str, "subtype": None},
@@ -963,8 +959,6 @@ class PythonConfig(object):
 
     def __init__(
         self,
-        tensor_data_types_config=None,
-        model_config_type=None,
         python_code=None,
         python_code_path=None,
         python_path=None,
@@ -974,8 +968,6 @@ class PythonConfig(object):
         return_all_inputs=None,
         setup_and_run=False,
     ):
-        self.__tensor_data_types_config = tensor_data_types_config
-        self.__model_config_type = model_config_type
         self.__python_code = python_code
         self.__python_code_path = python_code_path
         self.__python_path = python_path
@@ -984,28 +976,6 @@ class PythonConfig(object):
         self.__extra_inputs = extra_inputs
         self.__return_all_inputs = return_all_inputs
         self.__setup_and_run = setup_and_run
-
-    def _get_tensor_data_types_config(self):
-        return self.__tensor_data_types_config
-
-    def _set_tensor_data_types_config(self, value):
-        if not isinstance(value, TensorDataTypesConfig):
-            raise TypeError("tensorDataTypesConfig must be TensorDataTypesConfig")
-        self.__tensor_data_types_config = value
-
-    tensor_data_types_config = property(
-        _get_tensor_data_types_config, _set_tensor_data_types_config
-    )
-
-    def _get_model_config_type(self):
-        return self.__model_config_type
-
-    def _set_model_config_type(self, value):
-        if not isinstance(value, ModelConfigType):
-            raise TypeError("modelConfigType must be ModelConfigType")
-        self.__model_config_type = value
-
-    model_config_type = property(_get_model_config_type, _set_model_config_type)
 
     def _get_python_code(self):
         return self.__python_code
@@ -1101,18 +1071,6 @@ class PythonConfig(object):
 
     def as_dict(self):
         d = empty_type_dict(self)
-        if self.__tensor_data_types_config is not None:
-            d["tensorDataTypesConfig"] = (
-                self.__tensor_data_types_config.as_dict()
-                if hasattr(self.__tensor_data_types_config, "as_dict")
-                else self.__tensor_data_types_config
-            )
-        if self.__model_config_type is not None:
-            d["modelConfigType"] = (
-                self.__model_config_type.as_dict()
-                if hasattr(self.__model_config_type, "as_dict")
-                else self.__model_config_type
-            )
         if self.__python_code is not None:
             d["pythonCode"] = (
                 self.__python_code.as_dict()
@@ -1389,47 +1347,33 @@ class PipelineStep(object):
     """
 
     _types_map = {
-        "outputSchemas": {"type": dict, "subtype": None},
         "inputColumnNames": {"type": dict, "subtype": None},
         "outputColumnNames": {"type": dict, "subtype": None},
         "inputSchemas": {"type": dict, "subtype": None},
-        "inputNames": {"type": list, "subtype": str},
+        "outputSchemas": {"type": dict, "subtype": None},
         "outputNames": {"type": list, "subtype": str},
+        "inputNames": {"type": list, "subtype": str},
     }
     _formats_map = {
-        "inputNames": "table",
         "outputNames": "table",
+        "inputNames": "table",
     }
 
     def __init__(
         self,
-        output_schemas=None,
         input_column_names=None,
         output_column_names=None,
         input_schemas=None,
-        input_names=None,
+        output_schemas=None,
         output_names=None,
+        input_names=None,
     ):
-        self.__output_schemas = output_schemas
         self.__input_column_names = input_column_names
         self.__output_column_names = output_column_names
         self.__input_schemas = input_schemas
-        self.__input_names = input_names
+        self.__output_schemas = output_schemas
         self.__output_names = output_names
-
-    def _get_output_schemas(self):
-        return self.__output_schemas
-
-    def _set_output_schemas(self, value):
-        if (
-            not isinstance(value, dict)
-            and not isinstance(value, DictWrapper)
-            and not isinstance(value, DictWrapper)
-        ):
-            raise TypeError("outputSchemas must be type")
-        self.__output_schemas = value
-
-    output_schemas = property(_get_output_schemas, _set_output_schemas)
+        self.__input_names = input_names
 
     def _get_input_column_names(self):
         return self.__input_column_names
@@ -1473,17 +1417,19 @@ class PipelineStep(object):
 
     input_schemas = property(_get_input_schemas, _set_input_schemas)
 
-    def _get_input_names(self):
-        return self.__input_names
+    def _get_output_schemas(self):
+        return self.__output_schemas
 
-    def _set_input_names(self, value):
-        if not isinstance(value, list) and not isinstance(value, ListWrapper):
-            raise TypeError("inputNames must be list")
-        if not all(isinstance(i, str) for i in value):
-            raise TypeError("inputNames list valeus must be str")
-        self.__input_names = value
+    def _set_output_schemas(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("outputSchemas must be type")
+        self.__output_schemas = value
 
-    input_names = property(_get_input_names, _set_input_names)
+    output_schemas = property(_get_output_schemas, _set_output_schemas)
 
     def _get_output_names(self):
         return self.__output_names
@@ -1497,14 +1443,20 @@ class PipelineStep(object):
 
     output_names = property(_get_output_names, _set_output_names)
 
+    def _get_input_names(self):
+        return self.__input_names
+
+    def _set_input_names(self, value):
+        if not isinstance(value, list) and not isinstance(value, ListWrapper):
+            raise TypeError("inputNames must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("inputNames list valeus must be str")
+        self.__input_names = value
+
+    input_names = property(_get_input_names, _set_input_names)
+
     def as_dict(self):
         d = empty_type_dict(self)
-        if self.__output_schemas is not None:
-            d["outputSchemas"] = (
-                self.__output_schemas.as_dict()
-                if hasattr(self.__output_schemas, "as_dict")
-                else self.__output_schemas
-            )
         if self.__input_column_names is not None:
             d["inputColumnNames"] = (
                 self.__input_column_names.as_dict()
@@ -1523,13 +1475,19 @@ class PipelineStep(object):
                 if hasattr(self.__input_schemas, "as_dict")
                 else self.__input_schemas
             )
-        if self.__input_names is not None:
-            d["inputNames"] = [
-                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__input_names
-            ]
+        if self.__output_schemas is not None:
+            d["outputSchemas"] = (
+                self.__output_schemas.as_dict()
+                if hasattr(self.__output_schemas, "as_dict")
+                else self.__output_schemas
+            )
         if self.__output_names is not None:
             d["outputNames"] = [
                 p.as_dict() if hasattr(p, "as_dict") else p for p in self.__output_names
+            ]
+        if self.__input_names is not None:
+            d["inputNames"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__input_names
             ]
         return d
 
@@ -3000,6 +2958,173 @@ class ImageLoadingStep(PipelineStep):
                 self.__object_detection_config.as_dict()
                 if hasattr(self.__object_detection_config, "as_dict")
                 else self.__object_detection_config
+            )
+        return d
+
+
+class CustomStep(PipelineStep):
+
+    _types_map = {
+        "inputSchemas": {"type": dict, "subtype": None},
+        "outputSchemas": {"type": dict, "subtype": None},
+        "inputNames": {"type": list, "subtype": str},
+        "outputNames": {"type": list, "subtype": str},
+        "inputColumnNames": {"type": dict, "subtype": None},
+        "outputColumnNames": {"type": dict, "subtype": None},
+        "customUdfClazz": {"type": str, "subtype": None},
+    }
+    _formats_map = {
+        "inputNames": "table",
+        "outputNames": "table",
+    }
+
+    def __init__(
+        self,
+        input_schemas=None,
+        output_schemas=None,
+        input_names=None,
+        output_names=None,
+        input_column_names=None,
+        output_column_names=None,
+        custom_udf_clazz=None,
+    ):
+        self.__input_schemas = input_schemas
+        self.__output_schemas = output_schemas
+        self.__input_names = input_names
+        self.__output_names = output_names
+        self.__input_column_names = input_column_names
+        self.__output_column_names = output_column_names
+        self.__custom_udf_clazz = custom_udf_clazz
+
+    def _get_input_schemas(self):
+        return self.__input_schemas
+
+    def _set_input_schemas(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("inputSchemas must be type")
+        self.__input_schemas = value
+
+    input_schemas = property(_get_input_schemas, _set_input_schemas)
+
+    def _get_output_schemas(self):
+        return self.__output_schemas
+
+    def _set_output_schemas(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("outputSchemas must be type")
+        self.__output_schemas = value
+
+    output_schemas = property(_get_output_schemas, _set_output_schemas)
+
+    def _get_input_names(self):
+        return self.__input_names
+
+    def _set_input_names(self, value):
+        if not isinstance(value, list) and not isinstance(value, ListWrapper):
+            raise TypeError("inputNames must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("inputNames list valeus must be str")
+        self.__input_names = value
+
+    input_names = property(_get_input_names, _set_input_names)
+
+    def _get_output_names(self):
+        return self.__output_names
+
+    def _set_output_names(self, value):
+        if not isinstance(value, list) and not isinstance(value, ListWrapper):
+            raise TypeError("outputNames must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("outputNames list valeus must be str")
+        self.__output_names = value
+
+    output_names = property(_get_output_names, _set_output_names)
+
+    def _get_input_column_names(self):
+        return self.__input_column_names
+
+    def _set_input_column_names(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("inputColumnNames must be type")
+        self.__input_column_names = value
+
+    input_column_names = property(_get_input_column_names, _set_input_column_names)
+
+    def _get_output_column_names(self):
+        return self.__output_column_names
+
+    def _set_output_column_names(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("outputColumnNames must be type")
+        self.__output_column_names = value
+
+    output_column_names = property(_get_output_column_names, _set_output_column_names)
+
+    def _get_custom_udf_clazz(self):
+        return self.__custom_udf_clazz
+
+    def _set_custom_udf_clazz(self, value):
+        if not isinstance(value, str):
+            raise TypeError("customUdfClazz must be str")
+        self.__custom_udf_clazz = value
+
+    custom_udf_clazz = property(_get_custom_udf_clazz, _set_custom_udf_clazz)
+
+    def as_dict(self):
+        d = empty_type_dict(self)
+        if self.__input_schemas is not None:
+            d["inputSchemas"] = (
+                self.__input_schemas.as_dict()
+                if hasattr(self.__input_schemas, "as_dict")
+                else self.__input_schemas
+            )
+        if self.__output_schemas is not None:
+            d["outputSchemas"] = (
+                self.__output_schemas.as_dict()
+                if hasattr(self.__output_schemas, "as_dict")
+                else self.__output_schemas
+            )
+        if self.__input_names is not None:
+            d["inputNames"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__input_names
+            ]
+        if self.__output_names is not None:
+            d["outputNames"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__output_names
+            ]
+        if self.__input_column_names is not None:
+            d["inputColumnNames"] = (
+                self.__input_column_names.as_dict()
+                if hasattr(self.__input_column_names, "as_dict")
+                else self.__input_column_names
+            )
+        if self.__output_column_names is not None:
+            d["outputColumnNames"] = (
+                self.__output_column_names.as_dict()
+                if hasattr(self.__output_column_names, "as_dict")
+                else self.__output_column_names
+            )
+        if self.__custom_udf_clazz is not None:
+            d["customUdfClazz"] = (
+                self.__custom_udf_clazz.as_dict()
+                if hasattr(self.__custom_udf_clazz, "as_dict")
+                else self.__custom_udf_clazz
             )
         return d
 

--- a/python/konduit/base_inference.py
+++ b/python/konduit/base_inference.py
@@ -1167,12 +1167,12 @@ class ServingConfig(object):
     def __init__(
         self,
         http_port=None,
-        listen_host=None,
+        listen_host="localhost",
         input_data_format="NUMPY",
         output_data_format="NUMPY",
         prediction_type="RAW",
         uploads_directory="file-uploads/",
-        log_timings=None,
+        log_timings=False,
         metric_types=None,
     ):
         self.__http_port = http_port

--- a/python/konduit/base_inference.py
+++ b/python/konduit/base_inference.py
@@ -935,8 +935,6 @@ class PythonConfig(object):
     code either as string to `python_code` or as path to a Python script to `python_code_path`.
     Additionally, you can modify or extend your Python path by setting `python_path` accordingly.
 
-    :param tensor_data_types_config: konduit.TensorDataTypesConfig
-    :param model_config_type: konduit.ModelConfigType
     :param python_code: Python code as str
     :param python_code_path: full qualifying path to the Python script you want to run, as str
     :param python_inputs: list of Python input variable names
@@ -2906,6 +2904,173 @@ class ImageLoadingStep(PipelineStep):
                 self.__object_detection_config.as_dict()
                 if hasattr(self.__object_detection_config, "as_dict")
                 else self.__object_detection_config
+            )
+        return d
+
+
+class CustomStep(PipelineStep):
+
+    _types_map = {
+        "inputSchemas": {"type": dict, "subtype": None},
+        "outputSchemas": {"type": dict, "subtype": None},
+        "inputNames": {"type": list, "subtype": str},
+        "outputNames": {"type": list, "subtype": str},
+        "inputColumnNames": {"type": dict, "subtype": None},
+        "outputColumnNames": {"type": dict, "subtype": None},
+        "customUdfClazz": {"type": str, "subtype": None},
+    }
+    _formats_map = {
+        "inputNames": "table",
+        "outputNames": "table",
+    }
+
+    def __init__(
+        self,
+        input_schemas=None,
+        output_schemas=None,
+        input_names=None,
+        output_names=None,
+        input_column_names=None,
+        output_column_names=None,
+        custom_udf_clazz=None,
+    ):
+        self.__input_schemas = input_schemas
+        self.__output_schemas = output_schemas
+        self.__input_names = input_names
+        self.__output_names = output_names
+        self.__input_column_names = input_column_names
+        self.__output_column_names = output_column_names
+        self.__custom_udf_clazz = custom_udf_clazz
+
+    def _get_input_schemas(self):
+        return self.__input_schemas
+
+    def _set_input_schemas(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("inputSchemas must be type")
+        self.__input_schemas = value
+
+    input_schemas = property(_get_input_schemas, _set_input_schemas)
+
+    def _get_output_schemas(self):
+        return self.__output_schemas
+
+    def _set_output_schemas(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("outputSchemas must be type")
+        self.__output_schemas = value
+
+    output_schemas = property(_get_output_schemas, _set_output_schemas)
+
+    def _get_input_names(self):
+        return self.__input_names
+
+    def _set_input_names(self, value):
+        if not isinstance(value, list) and not isinstance(value, ListWrapper):
+            raise TypeError("inputNames must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("inputNames list valeus must be str")
+        self.__input_names = value
+
+    input_names = property(_get_input_names, _set_input_names)
+
+    def _get_output_names(self):
+        return self.__output_names
+
+    def _set_output_names(self, value):
+        if not isinstance(value, list) and not isinstance(value, ListWrapper):
+            raise TypeError("outputNames must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("outputNames list valeus must be str")
+        self.__output_names = value
+
+    output_names = property(_get_output_names, _set_output_names)
+
+    def _get_input_column_names(self):
+        return self.__input_column_names
+
+    def _set_input_column_names(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("inputColumnNames must be type")
+        self.__input_column_names = value
+
+    input_column_names = property(_get_input_column_names, _set_input_column_names)
+
+    def _get_output_column_names(self):
+        return self.__output_column_names
+
+    def _set_output_column_names(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("outputColumnNames must be type")
+        self.__output_column_names = value
+
+    output_column_names = property(_get_output_column_names, _set_output_column_names)
+
+    def _get_custom_udf_clazz(self):
+        return self.__custom_udf_clazz
+
+    def _set_custom_udf_clazz(self, value):
+        if not isinstance(value, str):
+            raise TypeError("customUdfClazz must be str")
+        self.__custom_udf_clazz = value
+
+    custom_udf_clazz = property(_get_custom_udf_clazz, _set_custom_udf_clazz)
+
+    def as_dict(self):
+        d = empty_type_dict(self)
+        if self.__input_schemas is not None:
+            d["inputSchemas"] = (
+                self.__input_schemas.as_dict()
+                if hasattr(self.__input_schemas, "as_dict")
+                else self.__input_schemas
+            )
+        if self.__output_schemas is not None:
+            d["outputSchemas"] = (
+                self.__output_schemas.as_dict()
+                if hasattr(self.__output_schemas, "as_dict")
+                else self.__output_schemas
+            )
+        if self.__input_names is not None:
+            d["inputNames"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__input_names
+            ]
+        if self.__output_names is not None:
+            d["outputNames"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__output_names
+            ]
+        if self.__input_column_names is not None:
+            d["inputColumnNames"] = (
+                self.__input_column_names.as_dict()
+                if hasattr(self.__input_column_names, "as_dict")
+                else self.__input_column_names
+            )
+        if self.__output_column_names is not None:
+            d["outputColumnNames"] = (
+                self.__output_column_names.as_dict()
+                if hasattr(self.__output_column_names, "as_dict")
+                else self.__output_column_names
+            )
+        if self.__custom_udf_clazz is not None:
+            d["customUdfClazz"] = (
+                self.__custom_udf_clazz.as_dict()
+                if hasattr(self.__custom_udf_clazz, "as_dict")
+                else self.__custom_udf_clazz
             )
         return d
 

--- a/python/konduit/load.py
+++ b/python/konduit/load.py
@@ -195,6 +195,8 @@ def get_step(step_config):
         step = get_model_step(step_config, step_type)
     elif step_type == 'IMAGE_LOADING':
         step = get_image_load_step(step_config)
+    elif step_type == 'CUSTOM':
+        step = get_custom_step(step_config)
     else:
         raise Exception("Step type of type " + step_type + " currently not supported.")
     return step
@@ -209,6 +211,7 @@ def get_python_step(step_config):
     python_config = PythonConfig(**step_config)
     step = PythonStep().step(python_config)
     return step
+
 
 def get_image_load_step(step_config):
     """Get a ImageLoadingStep from a configuration object
@@ -233,7 +236,7 @@ def get_model_step(step_config, step_type):
     )
     if (
         step_type == "TENSORFLOW"
-    ):  # TF has to extra properties, all others are identical
+    ):  # TF has two extra properties, all others are identical
         model_config = TensorFlowConfig(
             config_proto_path=pop_data(step_config, "config_proto_path"),
             saved_model_config=pop_data(step_config, "saved_model_config"),
@@ -248,6 +251,16 @@ def get_model_step(step_config, step_type):
     step_config["model_config"] = model_config
     step_config = extract_parallel_inference(step_config)
     step = ModelStep(**step_config)
+    return step
+
+
+def get_custom_step(step_config):
+    """Get a CustomStep from a configuration object
+
+    :param step_config: python dictionary with properties to create a PipelineStep
+    :return: konduit.inference.CustomStep instance.
+    """
+    step = CustomStep(**step_config)
     return step
 
 

--- a/python/tests/test_load_yaml.py
+++ b/python/tests/test_load_yaml.py
@@ -78,6 +78,13 @@ def test_tensor_flow_serving():
     del server
 
 
+@pytest.mark.unit
+def test_custom_step_serving():
+    file_path = "yaml/konduit_custom_step.yaml"
+    server = server_from_file(file_path=file_path)
+    del server
+
+
 @pytest.mark.integration
 def test_yaml_server_python_prediction():
     try:

--- a/python/tests/yaml/konduit_custom_step.yaml
+++ b/python/tests/yaml/konduit_custom_step.yaml
@@ -1,0 +1,8 @@
+serving:
+  http_port: 1337
+steps:
+  custom_step_one:
+    type: CUSTOM
+    custom_udf_clazz: io.konduit.serving.custom.CustomStepClass # This is a dummy class name just to test the custom step initialization from yaml file
+client:
+  port: 1337


### PR DESCRIPTION
You can create a Custom Step from yaml like this:

`custom_step.yaml` file:
```
serving:
  http_port: 1337
steps:
  custom_step_one:
    type: CUSTOM
    custom_udf_clazz: <class_name>
client:
  port: 1337
```

From the server code side:
```
file_path = "custom_step.yaml"
server = server_from_file(file_path=file_path, start_server=True)
```

Remember to put the jar containing the extra class in the classpath of the server: #197 