### PR TITLE
Use tensorflow-platform-python-gpu artifact

### DIFF
--- a/konduit-serving-gpu/pom.xml
+++ b/konduit-serving-gpu/pom.xml
@@ -35,6 +35,11 @@
             <version>${cuda.javacpp.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>tensorflow-platform-python-gpu</artifactId>
+            <version>${tensorflow.javacpp.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.nd4j</groupId>
@@ -46,85 +51,4 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>tensorflow-windows-os-gpu</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.bytedeco</groupId>
-                    <artifactId>tensorflow</artifactId>
-                    <version>${tensorflow.javacpp.version}</version>
-                    <classifier>windows-x86_64-python-gpu</classifier>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>org.bytedeco</groupId>
-                            <artifactId>mkl-dnn</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.bytedeco</groupId>
-                            <artifactId>mkl-dnn-platform</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>tensorflow-mac-os-gpu</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.bytedeco</groupId>
-                    <artifactId>tensorflow</artifactId>
-                    <version>${tensorflow.javacpp.version}</version>
-                    <classifier>macosx-x86_64-python-gpu</classifier>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>org.bytedeco</groupId>
-                            <artifactId>mkl-dnn</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.bytedeco</groupId>
-                            <artifactId>mkl-dnn-platform</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>tensorflow-linux-os-gpu</id>
-            <activation>
-                <os>
-                    <family>linux</family>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.bytedeco</groupId>
-                    <artifactId>tensorflow</artifactId>
-                    <version>${tensorflow.javacpp.version}</version>
-                    <classifier>linux-x86_64-python-gpu</classifier>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>org.bytedeco</groupId>
-                            <artifactId>mkl-dnn</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.bytedeco</groupId>
-                            <artifactId>mkl-dnn-platform</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Instead of custom profiles. This way, we get the artifacts that we need with the usual `mvn -Djavacpp.platform...` properties, for example, `mvn dependency:tree -Djavacpp.platform.custom -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64`:
```
...
[INFO] +- org.bytedeco:tensorflow-platform-python-gpu:jar:1.15.0-1.5.2:compile
[INFO] |  +- org.bytedeco:numpy-platform:jar:1.17.3-1.5.2:compile
[INFO] |  |  +- org.bytedeco:cpython-platform:jar:3.7.5-1.5.2:compile
[INFO] |  |  |  +- org.bytedeco:cpython:jar:3.7.5-1.5.2:compile
[INFO] |  |  |  +- org.bytedeco:cpython:jar:linux-x86_64:3.7.5-1.5.2:compile
[INFO] |  |  |  \- org.bytedeco:cpython:jar:windows-x86_64:3.7.5-1.5.2:compile
[INFO] |  |  +- org.bytedeco:numpy:jar:1.17.3-1.5.2:compile
[INFO] |  |  +- org.bytedeco:numpy:jar:linux-x86_64:1.17.3-1.5.2:compile
[INFO] |  |  \- org.bytedeco:numpy:jar:windows-x86_64:1.17.3-1.5.2:compile
[INFO] |  +- org.bytedeco:mkl-dnn-platform:jar:0.21.2-1.5.2:compile
[INFO] |  |  +- org.bytedeco:mkl-dnn:jar:0.21.2-1.5.2:compile
[INFO] |  |  +- org.bytedeco:mkl-dnn:jar:linux-x86_64:0.21.2-1.5.2:compile
[INFO] |  |  \- org.bytedeco:mkl-dnn:jar:windows-x86_64:0.21.2-1.5.2:compile
[INFO] |  +- org.bytedeco:tensorflow:jar:linux-x86_64-python-gpu:1.15.0-1.5.2:compile
[INFO] |  \- org.bytedeco:tensorflow:jar:windows-x86_64-python-gpu:1.15.0-1.5.2:compile
...
```