### PR TITLE
Cleaning up serving config

### DIFF
--- a/konduit-serving-api/src/main/java/ai/konduit/serving/config/ServingConfig.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/config/ServingConfig.java
@@ -45,13 +45,9 @@ public class ServingConfig {
 
     @Builder.Default
     private String listenHost = "localhost";
-    @Builder.Default
-    private Input.DataFormat inputDataFormat = Input.DataFormat.JSON;
-    @Builder.Default
-    private Output.DataFormat outputDataFormat = Output.DataFormat.JSON;
 
     @Builder.Default
-    private Output.PredictionType predictionType = PredictionType.RAW;
+    private Output.DataFormat outputDataFormat = Output.DataFormat.JSON;
 
     @Builder.Default
     private String uploadsDirectory = "file-uploads/";

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/BasePipelineStep.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/BasePipelineStep.java
@@ -222,10 +222,11 @@ public abstract class BasePipelineStep<T extends BasePipelineStep<T>> implements
      */
     @Override
     public Schema outputSchemaForName(String name) {
-        Preconditions.checkNotNull(outputSchemas, "No output schemas specified in configuration!");
-
-        if (!outputSchemas.containsKey(name))
+        // Commenting the line because there are cases where the outputSchemas are null but the configuration is valid.
+        // Preconditions.checkNotNull(outputSchemas, "No output schemas specified in configuration!");
+        if (outputSchemas == null || !outputSchemas.containsKey(name))
             return null;
+
         return SchemaTypeUtils.toSchema(outputSchemas.get(name),
                 outputColumnNames.get(name));
     }
@@ -235,8 +236,9 @@ public abstract class BasePipelineStep<T extends BasePipelineStep<T>> implements
      */
     @Override
     public Schema inputSchemaForName(String name) {
-        Preconditions.checkNotNull(inputSchemas, "No input schemas specified in configuration!");
-        if (!inputSchemas.containsKey(name))
+        // Commenting the line below because there are cases where the inputSchemas are null but the configuration is valid.
+        // Preconditions.checkNotNull(inputSchemas, "No input schemas specified in configuration!");
+        if (inputSchemas == null || !inputSchemas.containsKey(name))
             return null;
 
         return SchemaTypeUtils.toSchema(inputTypesForName(name),

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/BasePipelineStep.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/BasePipelineStep.java
@@ -24,8 +24,10 @@ package ai.konduit.serving.pipeline;
 import ai.konduit.serving.config.Output.PredictionType;
 import ai.konduit.serving.config.SchemaType;
 import ai.konduit.serving.util.SchemaTypeUtils;
-import lombok.*;
-import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.datavec.api.transform.schema.Schema;
@@ -105,7 +107,7 @@ public abstract class BasePipelineStep<T extends BasePipelineStep<T>> implements
             this.inputColumnNames.put("default",Arrays.asList("default"));
         }
 
-        if(SchemaTypeUtils.allIsNullOrEmpty(this.outputNames,this.outputSchemas,this.outputColumnNames)) {
+        if(!SchemaTypeUtils.allIsNullOrEmpty(this.outputNames,this.outputSchemas,this.outputColumnNames)) {
             Set<String> outputNamesTest = new HashSet<>(this.outputNames);
             if(SchemaTypeUtils.anyIsNullOrEmpty(outputSchemas,outputColumnNames)) {
                 outputColumnNames = new LinkedHashMap<>();

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/step/PythonStep.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/pipeline/step/PythonStep.java
@@ -121,16 +121,16 @@ public class PythonStep extends BasePipelineStep<PythonStep> {
         try {
             switch (pythonVarType) {
                 case BOOL:
-                    return ai.konduit.serving.config.SchemaType.Boolean;
+                    return SchemaType.Boolean;
                 case STR:
-                    return ai.konduit.serving.config.SchemaType.String;
+                    return SchemaType.String;
                 case INT:
-                    return ai.konduit.serving.config.SchemaType.Integer;
+                    return SchemaType.Integer;
                 case FLOAT:
-                    return ai.konduit.serving.config.SchemaType.Float;
+                    return SchemaType.Float;
                 case NDARRAY:
-                    return ai.konduit.serving.config.SchemaType.NDArray;
                 case LIST:
+                    return SchemaType.NDArray;
                 case FILE:
                 case DICT:
                 default:

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/util/SchemaTypeUtils.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/util/SchemaTypeUtils.java
@@ -94,13 +94,15 @@ public class SchemaTypeUtils {
      * @param collection the collection to check* @return
      */
     public static  boolean isNullOrEmpty(Object collection) {
+        if(collection == null) return true;
+
         if(collection instanceof Map) {
             Map map = (Map) collection;
-            return map == null || map.isEmpty();
+            return map.isEmpty();
         }
         else if(collection instanceof Collection) {
             Collection collection1 = (Collection) collection;
-            return collection1 == null || collection1.isEmpty();
+            return collection1.isEmpty();
         }
         else
             throw new IllegalArgumentException("Passed in type must be a collection or map");

--- a/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/PythonDocStrings.java
+++ b/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/PythonDocStrings.java
@@ -226,9 +226,7 @@ public class PythonDocStrings {
                         "\n" +
                         "    :param http_port: HTTP port of the konduit.Server\n" +
                         "    :param listen_host: host of the konduit.Server, defaults to 'localhost'\n" +
-                        "    :param input_data_format: Input data format, see konduit.Input for more information\n" +
                         "    :param output_data_format: Output data format, see konduit.Output for more information\n" +
-                        "    :param prediction_type: Prediction type, see konduit.Output for more information\n" +
                         "    :param uploads_directory: to which directory to store file uploads to, defaults to 'file-uploads/'\n" +
                         "    :param log_timings: whether to log timings for this config, defaults to False\n" +
                         "    :param metric_types: the types of metrics logged for your ServingConfig can currently only be configured and\n" +

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
@@ -321,11 +321,12 @@ public class PipelineRouteDefiner {
 
         });
 
-        // TODO: predictionType is unused, why put it into the route?
         router.post("/:predictionType/:inputDataFormat")
                 .consumes("multipart/form-data")
                 .consumes("multipart/mixed")
                 .produces("application/json").handler(ctx -> {
+            PredictionType predictionType = PredictionType.valueOf(ctx.pathParam("predictionType").toUpperCase());
+
             String transactionUUID = ctx.get(VerticleConstants.TRANSACTION_ID);
             //need to initialize schemas for output
             initializeSchemas(inferenceConfiguration, false);
@@ -354,7 +355,7 @@ public class PipelineRouteDefiner {
 
                     pipelineExecutioner.doInference(
                             ctx,
-                            inferenceConfiguration.getServingConfig().getPredictionType(),
+                            predictionType,
                             inputs,
                             inputSchema,
                             null,
@@ -473,7 +474,7 @@ public class PipelineRouteDefiner {
             //note that we initialize this after the verticle is started
             //due to needing to sometime initialize retraining routes
             try {
-                pipelineExecutioner = new PipelineExecutioner(inferenceConfiguration);
+                pipelineExecutioner = new PipelineExecutioner(inferenceConfiguration, null, null);
                 pipelineExecutioner.init();
 
             } catch (Exception e) {

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
@@ -36,6 +36,7 @@ import ai.konduit.serving.pipeline.handlers.converter.multi.converter.impl.arrow
 import ai.konduit.serving.pipeline.handlers.converter.multi.converter.impl.image.VertxBufferImageInputAdapter;
 import ai.konduit.serving.pipeline.handlers.converter.multi.converter.impl.nd4j.VertxBufferNd4jInputAdapter;
 import ai.konduit.serving.pipeline.handlers.converter.multi.converter.impl.numpy.VertxBufferNumpyInputAdapter;
+import ai.konduit.serving.pipeline.step.ModelStep;
 import ai.konduit.serving.pipeline.step.PmmlStep;
 import ai.konduit.serving.pipeline.step.PythonStep;
 import ai.konduit.serving.pipeline.step.TransformProcessStep;
@@ -76,6 +77,10 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Getter
 public class PipelineRouteDefiner {
+
+    protected Input.DataFormat inputDataFormat;
+    protected PredictionType predictionType;
+    protected Output.DataFormat outputDataFormat;
 
     protected PipelineExecutioner pipelineExecutioner;
     protected InferenceConfiguration inferenceConfiguration;
@@ -237,13 +242,18 @@ public class PipelineRouteDefiner {
         /**
          * Get the output of a pipeline for a given prediction type for JSON input data format.
          */
-        // TODO: this json specific route assumes a single input and output called "default".
-        //  That seems very restrictive. Also, using this for a data format other than JSON does not make sense.
-        //  Consider renaming this route to "/:predictionType/JSON" for clarity.
         router.post("/:predictionType/:inputDataFormat")
                 .consumes("application/json")
                 .produces("application/json").handler(ctx -> {
-            PredictionType predictionType = PredictionType.valueOf(ctx.pathParam("predictionType").toUpperCase());
+            predictionType = PredictionType.valueOf(ctx.pathParam("predictionType").toUpperCase());
+            inputDataFormat = Input.DataFormat.valueOf(ctx.pathParam("inputDataFormat").toUpperCase());
+
+            Preconditions.checkState(inputDataFormat.equals(Input.DataFormat.JSON),
+                    "content-type: application/json only accepts JSON as " +
+                            "input data format and not " + inputDataFormat.name());
+
+            pipelineExecutioner.init(inputDataFormat, predictionType);
+
             initializeSchemas(inferenceConfiguration, true);
 
             try {
@@ -274,10 +284,23 @@ public class PipelineRouteDefiner {
         /**
          * Multi-part request for pipeline outputs of given predictionType for
          */
-        // TODO: predictionType is unused, why put it into the route?
         router.post("/:predictionType/:inputDataFormat")
                 .consumes("multipart/form-data")
                 .consumes("multipart/mixed").handler(ctx -> {
+            inputDataFormat = Input.DataFormat.valueOf(ctx.pathParam("inputDataFormat").toUpperCase());
+
+            try {
+                // Sometimes we have predictionType coming in as outputDataFormat if that's the case
+                // then the right place for the pipelineExecutioner to be initialized is at the
+                // "/:outputDataFormat/:inputDataFormat" route
+                outputDataFormat = Output.DataFormat.valueOf(ctx.pathParam("predictionType").toUpperCase());
+                predictionType = PredictionType.RAW;
+            } catch(Exception e) {
+                predictionType = PredictionType.valueOf(ctx.pathParam("predictionType").toUpperCase());
+            }
+
+            pipelineExecutioner.init(inputDataFormat, predictionType);
+
             Map<String, InputAdapter<io.vertx.core.buffer.Buffer, ?>> adapters = getInputAdapterMap(ctx);
 
             BatchInputParser batchInputParser = BatchInputParser.builder()
@@ -300,7 +323,6 @@ public class PipelineRouteDefiner {
                         start.stop();
                 } catch (Exception e) {
                     log.error("Unable to convert data for batch", e);
-
                 }
 
                 long endNanos = System.nanoTime();
@@ -325,8 +347,6 @@ public class PipelineRouteDefiner {
                 .consumes("multipart/form-data")
                 .consumes("multipart/mixed")
                 .produces("application/json").handler(ctx -> {
-            PredictionType predictionType = PredictionType.valueOf(ctx.pathParam("predictionType").toUpperCase());
-
             String transactionUUID = ctx.get(VerticleConstants.TRANSACTION_ID);
             //need to initialize schemas for output
             initializeSchemas(inferenceConfiguration, false);
@@ -431,6 +451,7 @@ public class PipelineRouteDefiner {
                 .consumes("multipart/form-data")
                 .consumes("multipart/mixed")
                 .produces("application/octet-stream").handler((RoutingContext ctx) -> {
+
             Record[] inputs = ctx.get(VerticleConstants.CONVERTED_INFERENCE_DATA);
             if (inputs == null) {
                 log.warn("No inputs found. Bad request");
@@ -463,24 +484,18 @@ public class PipelineRouteDefiner {
                     handler.fail(e);
                 }
 
-            }, true, result -> {
-            });
-
+            }, true, result -> {});
         });
-
 
         if (pipelineExecutioner == null) {
             log.debug("Initializing inference executioner after starting verticle");
             //note that we initialize this after the verticle is started
             //due to needing to sometime initialize retraining routes
             try {
-                pipelineExecutioner = new PipelineExecutioner(inferenceConfiguration, null, null);
-                pipelineExecutioner.init();
-
+                pipelineExecutioner = new PipelineExecutioner(inferenceConfiguration);
             } catch (Exception e) {
                 log.error("Failed to initialize. Shutting down.", e);
             }
-
         } else {
             log.debug("Web server and endpoint already initialized.");
         }
@@ -491,7 +506,7 @@ public class PipelineRouteDefiner {
     private void initializeSchemas(InferenceConfiguration inferenceConfiguration, boolean inputRequired) {
         if (inputSchema == null && inputRequired) {
             for (PipelineStep pipelineStep : inferenceConfiguration.getSteps()) {
-                if (pipelineStep instanceof PmmlStep || pipelineStep instanceof PythonStep || pipelineStep
+                if (pipelineStep instanceof ModelStep || pipelineStep instanceof PythonStep || pipelineStep
                         instanceof TransformProcessStep) {
                     inputSchema = pipelineStep.inputSchemaForName("default");
                 }
@@ -500,7 +515,7 @@ public class PipelineRouteDefiner {
 
         if (outputSchema == null) {
             for (PipelineStep pipelineStep : inferenceConfiguration.getSteps()) {
-                if (pipelineStep instanceof PmmlStep || pipelineStep instanceof PythonStep || pipelineStep
+                if (pipelineStep instanceof ModelStep || pipelineStep instanceof PythonStep || pipelineStep
                         instanceof TransformProcessStep) {
                     outputSchema = pipelineStep.outputSchemaForName("default");
                 }

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/executioner/PipelineExecutioner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/executioner/PipelineExecutioner.java
@@ -580,7 +580,8 @@ public class PipelineExecutioner {
      * among other components)
      */
     public void destroy() {
-        pipeline.destroy();
+        if(pipeline != null)
+            pipeline.destroy();
     }
 
 

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/executioner/PipelineExecutioner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/executioner/PipelineExecutioner.java
@@ -115,8 +115,12 @@ public class PipelineExecutioner {
     private static RegressionMultiOutputAdapter regressionMultiOutputAdapter = new RegressionMultiOutputAdapter();
     private static RawMultiOutputAdapter rawMultiOutputAdapter = new RawMultiOutputAdapter();
 
-    public PipelineExecutioner(InferenceConfiguration inferenceConfiguration) {
+    public PipelineExecutioner(InferenceConfiguration inferenceConfiguration,
+                               Input.DataFormat inputDataFormat,
+                               PredictionType predictionType) {
         this.config = inferenceConfiguration;
+        this.inputDataFormat = inputDataFormat;
+        this.predictionType = predictionType;
     }
 
     /**
@@ -293,7 +297,7 @@ public class PipelineExecutioner {
 
         try {
             if (servingConfig.getOutputDataFormat() == Output.DataFormat.JSON) {
-                multiOutputAdapter = outputAdapterFor(config().serving().getPredictionType(), objectDetectionConfig);
+                multiOutputAdapter = outputAdapterFor(predictionType, objectDetectionConfig);
             } else {
                 log.info("Skipping initialization of multi input adapter due to binary output.");
             }
@@ -361,7 +365,7 @@ public class PipelineExecutioner {
                 multiOutputAdapter = new RegressionMultiOutputAdapter();
                 break;
             default:
-                throw new IllegalStateException("Illegal type for output type " + config.serving().getPredictionType());
+                throw new IllegalStateException("Illegal type for output type " + predictionType);
         }
 
         return multiOutputAdapter;

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/executioner/PipelineExecutioner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/executioner/PipelineExecutioner.java
@@ -90,9 +90,6 @@ import java.util.zip.ZipOutputStream;
 @Slf4j
 public class PipelineExecutioner {
 
-    Input.DataFormat inputDataFormat;
-    PredictionType predictionType;
-
     @Getter
     protected MultiOutputAdapter multiOutputAdapter;
     protected List<String> inputNames, outputNames;
@@ -115,12 +112,8 @@ public class PipelineExecutioner {
     private static RegressionMultiOutputAdapter regressionMultiOutputAdapter = new RegressionMultiOutputAdapter();
     private static RawMultiOutputAdapter rawMultiOutputAdapter = new RawMultiOutputAdapter();
 
-    public PipelineExecutioner(InferenceConfiguration inferenceConfiguration,
-                               Input.DataFormat inputDataFormat,
-                               PredictionType predictionType) {
+    public PipelineExecutioner(InferenceConfiguration inferenceConfiguration) {
         this.config = inferenceConfiguration;
-        this.inputDataFormat = inputDataFormat;
-        this.predictionType = predictionType;
     }
 
     /**
@@ -227,7 +220,6 @@ public class PipelineExecutioner {
     }
 
     private void validateInputsAndOutputs(Input.DataFormat inputDataformat,
-                                          Output.DataFormat outputDataformat,
                                           PredictionType predictionType) {
         //configure validation for input and output
         if(!config.getSteps().isEmpty()) {
@@ -239,7 +231,7 @@ public class PipelineExecutioner {
                             + startingPipelineStep.getClass().getName() + " expected input types were "
                             + Arrays.toString(startingPipelineStep.validInputTypes())
                             + ". If this list is null or empty, then any type is considered valid.");
-            Preconditions.checkState(finalPipelineStep.isValidOutputType(outputDataformat),
+            Preconditions.checkState(finalPipelineStep.isValidOutputType(config.getServingConfig().getOutputDataFormat()),
                     "Configured output type is invalid for final pipeline step of type "
                             + finalPipelineStep.getClass().getName() + " expected output types were "
                             + Arrays.toString(finalPipelineStep.validInputTypes())
@@ -255,13 +247,13 @@ public class PipelineExecutioner {
     /**
      * Init the pipeline executioner.
      */
-    public void init() {
+    public void init(Input.DataFormat inputDataFormat, PredictionType predictionType) {
         ServingConfig servingConfig = config.getServingConfig();
         if(config.getSteps().isEmpty()) {
             log.warn("No pipeline steps configured.");
         }
 
-        validateInputsAndOutputs(inputDataFormat, servingConfig.getOutputDataFormat(), predictionType);
+        validateInputsAndOutputs(inputDataFormat, predictionType);
 
         this.pipeline = Pipeline.getPipeline(config.getSteps());
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/configprovider/KonduitServingMainTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/configprovider/KonduitServingMainTest.java
@@ -140,7 +140,6 @@ public class KonduitServingMainTest {
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(getAvailablePort())
-                .predictionType(Output.PredictionType.CLASSIFICATION)
                 .build();
 
         ModelConfig modelConfig = ModelConfig.builder()

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/configprovider/KonduitServingMainTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/configprovider/KonduitServingMainTest.java
@@ -23,7 +23,6 @@
 package ai.konduit.serving.configprovider;
 
 import ai.konduit.serving.InferenceConfiguration;
-import ai.konduit.serving.config.Output;
 import ai.konduit.serving.config.ServingConfig;
 import ai.konduit.serving.input.conversion.BatchInputParser;
 import ai.konduit.serving.model.ModelConfig;
@@ -41,7 +40,10 @@ import org.apache.commons.io.FileUtils;
 import org.datavec.api.transform.schema.Schema;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.util.ModelSerializer;
-import org.junit.*;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/PipelineExecutionerTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/PipelineExecutionerTests.java
@@ -32,9 +32,7 @@ import ai.konduit.serving.pipeline.step.ModelStep;
 import ai.konduit.serving.pipeline.step.PythonStep;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.RoutingContext;
 import junit.framework.TestCase;
-import org.datavec.python.PythonVariables;
 import org.datavec.python.PythonVariables.Type;
 import org.junit.Test;
 import org.nd4j.linalg.factory.Nd4j;
@@ -53,12 +51,9 @@ public class PipelineExecutionerTests {
 
     @Test
     public void testDoJsonInference() {
-        ParallelInferenceConfig parallelInferenceConfig = ParallelInferenceConfig.defaultConfig();
         int port = 1111;
 
         ServingConfig servingConfig = ServingConfig.builder()
-                .predictionType(Output.PredictionType.RAW)
-                .inputDataFormat(Input.DataFormat.IMAGE)
                 .httpPort(port)
                 .build();
 
@@ -69,7 +64,7 @@ public class PipelineExecutionerTests {
 
         List<String> fieldNames = Arrays.stream(values)
                 .filter(input -> input == SchemaType.Boolean)
-                .map(input -> input.name())
+                .map(Enum::name)
                 .collect(Collectors.toList());
         Map<String,PythonConfig> namesToPythonConfig = new LinkedHashMap<>();
         PythonConfigBuilder pythonConfig = PythonConfig.builder();
@@ -158,11 +153,11 @@ public class PipelineExecutionerTests {
 
         InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
                 .servingConfig(servingConfig)
-                .steps(Arrays.asList(pythonStep))
+                .steps(Collections.singletonList(pythonStep))
                 .build();
 
         PipelineExecutioner pipelineExecutioner = new PipelineExecutioner(inferenceConfiguration);
-        pipelineExecutioner.init();
+        pipelineExecutioner.init(Input.DataFormat.IMAGE, Output.PredictionType.RAW);
         // Run the test
         pipelineExecutioner.doJsonInference(wrapper,null);
     }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/PipelineExecutionerTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/PipelineExecutionerTests.java
@@ -68,8 +68,6 @@ public class PipelineExecutionerTests {
 
 
         ServingConfig servingConfig = ServingConfig.builder()
-                .predictionType(Output.PredictionType.RAW)
-                .inputDataFormat(Input.DataFormat.IMAGE)
                 .httpPort(port)
                 .build();
 
@@ -87,7 +85,7 @@ public class PipelineExecutionerTests {
                 .build();
 
         PipelineExecutioner pipelineExecutioner = new PipelineExecutioner(configuration);
-        pipelineExecutioner.init();
+        pipelineExecutioner.init(Input.DataFormat.IMAGE, Output.PredictionType.RAW);
         assertNotNull("Input names should not be null.", pipelineExecutioner.inputNames());
         assertNotNull("Output names should not be null.", pipelineExecutioner.outputNames());
         assertNotNull(pipelineExecutioner.inputDataTypes);
@@ -117,8 +115,6 @@ public class PipelineExecutionerTests {
                 .build();
 
         ServingConfig servingConfig = ServingConfig.builder()
-                .inputDataFormat(Input.DataFormat.IMAGE)
-                .predictionType(Output.PredictionType.YOLO)
                 .outputDataFormat(Output.DataFormat.JSON)
                 .httpPort(port)
                 .build();
@@ -142,7 +138,7 @@ public class PipelineExecutionerTests {
                 .build();
 
         PipelineExecutioner pipelineExecutioner = new PipelineExecutioner(configuration);
-        pipelineExecutioner.init();
+        pipelineExecutioner.init(Input.DataFormat.IMAGE, Output.PredictionType.YOLO);
         assertNotNull("Input names should not be null.", pipelineExecutioner.inputNames());
         assertNotNull("Output names should not be null.", pipelineExecutioner.outputNames());
         TestCase.assertEquals(TensorDataType.INT64, pipelineExecutioner.inputDataTypes.get("image_tensor"));

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/nd4j/memmap/MemMapArrayResultRangeJsonVerticleTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/nd4j/memmap/MemMapArrayResultRangeJsonVerticleTest.java
@@ -37,28 +37,15 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 @RunWith(VertxUnitRunner.class)
 @NotThreadSafe
-public class MemMapArrayResultRangeJsonVerticleTest extends ai.konduit.serving.verticles.nd4j.memmap.BaseMemMapTest {
-
+public class MemMapArrayResultRangeJsonVerticleTest extends BaseMemMapTest {
 
     @Override
     public Handler<HttpServerRequest> getRequest() {
-        Handler<HttpServerRequest> ret = new Handler<HttpServerRequest>() {
-            @Override
-            public void handle(HttpServerRequest req) {
-                //should be json body of classification
-                req.bodyHandler(body -> {
-                    System.out.println("Finish body" + body);
-                });
-
-                req.exceptionHandler(exception -> {
-                    exception.printStackTrace();
-                });
-
-
-            }
+        return req -> {
+            //should be json body of classification
+            req.bodyHandler(body -> System.out.println("Finish body" + body)).
+                    exceptionHandler(Throwable::printStackTrace);
         };
-
-        return ret;
     }
 
     @Test(timeout = 60000)
@@ -90,5 +77,4 @@ public class MemMapArrayResultRangeJsonVerticleTest extends ai.konduit.serving.v
 
         async.await();
     }
-
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/ndarray/BaseDl4JVerticalTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/ndarray/BaseDl4JVerticalTest.java
@@ -102,8 +102,6 @@ public abstract class BaseDl4JVerticalTest extends BaseVerticleTest {
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
-                .inputDataFormat(Input.DataFormat.JSON)
-                .predictionType(Output.PredictionType.CLASSIFICATION)
                 .build();
 
         PipelineStep modelPipelineStep = new ModelStep(modelConfig)

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/ndarray/ColumnarTransformProcessesTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/ndarray/ColumnarTransformProcessesTest.java
@@ -114,8 +114,6 @@ public class ColumnarTransformProcessesTest extends BaseDl4JVerticalTest {
         TransformProcessStep transformStep = new TransformProcessStep(transformProcess, outputSchema);
 
         ServingConfig servingConfig = ServingConfig.builder()
-                .predictionType(Output.PredictionType.CLASSIFICATION)
-                .inputDataFormat(Input.DataFormat.JSON)
                 .httpPort(port)
                 .build();
 
@@ -153,7 +151,7 @@ public class ColumnarTransformProcessesTest extends BaseDl4JVerticalTest {
         given().contentType(ContentType.JSON)
                 .body(wrapper.toString())
                 .port(port)
-                .post("/classification/csv")
+                .post("/classification/json")
                 .then().statusCode(200);
 
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/ndarray/ColumnarVerticleTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/ndarray/ColumnarVerticleTest.java
@@ -59,7 +59,7 @@ public class ColumnarVerticleTest extends BaseDl4JVerticalTest {
                 .contentType(ContentType.JSON)
                 .port(port)
                 .when()
-                .post("/classification/csv").andReturn();
+                .post("/classification/json").andReturn();
     }
 
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/pmml/PmmlIrisTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/pmml/PmmlIrisTest.java
@@ -113,6 +113,7 @@ public class PmmlIrisTest extends BaseVerticleTest {
                         SchemaType.Double,
                         SchemaType.Double,
                 })
+                .outputName("default")
                 .outputColumnName("default", Collections.singletonList("class"))
                 .outputSchema("default", new SchemaType[]{SchemaType.String})
                 .build();

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/pmml/PmmlIrisTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/pmml/PmmlIrisTest.java
@@ -95,9 +95,7 @@ public class PmmlIrisTest extends BaseVerticleTest {
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
-                .inputDataFormat(DataFormat.JSON)
                 .outputDataFormat(ai.konduit.serving.config.Output.DataFormat.JSON)
-                .predictionType(ai.konduit.serving.config.Output.PredictionType.RAW)
                 .build();
 
         ai.konduit.serving.pipeline.step.PmmlStep pmmlPipelineStep = ai.konduit.serving.pipeline.step.PmmlStep.builder()

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/pmml/PmmlIrisTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/pmml/PmmlIrisTest.java
@@ -23,12 +23,12 @@
 package ai.konduit.serving.verticles.pmml;
 
 import ai.konduit.serving.InferenceConfiguration;
-import ai.konduit.serving.config.Input.DataFormat;
 import ai.konduit.serving.config.Output;
 import ai.konduit.serving.config.SchemaType;
 import ai.konduit.serving.config.ServingConfig;
 import ai.konduit.serving.model.ModelConfigType;
 import ai.konduit.serving.model.PmmlConfig;
+import ai.konduit.serving.pipeline.step.PmmlStep;
 import ai.konduit.serving.verticles.BaseVerticleTest;
 import ai.konduit.serving.verticles.inference.InferenceVerticle;
 import io.vertx.core.AbstractVerticle;
@@ -46,6 +46,7 @@ import org.nd4j.linalg.io.ClassPathResource;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static ai.konduit.serving.executioner.PipelineExecutioner.convertBatchOutput;
@@ -81,9 +82,8 @@ public class PmmlIrisTest extends BaseVerticleTest {
             req.bodyHandler(body -> {
                 System.out.println(body.toJson());
                 System.out.println("Finish body" + body);
-            });
-
-            req.exceptionHandler(exception -> context.fail(exception));
+            })
+            .exceptionHandler(exception -> context.fail(exception));
         };
     }
 
@@ -98,8 +98,9 @@ public class PmmlIrisTest extends BaseVerticleTest {
                 .outputDataFormat(ai.konduit.serving.config.Output.DataFormat.JSON)
                 .build();
 
-        ai.konduit.serving.pipeline.step.PmmlStep pmmlPipelineStep = ai.konduit.serving.pipeline.step.PmmlStep.builder()
+        PmmlStep pmmlPipelineStep = PmmlStep.builder()
                 .modelConfig(pmmlConfig)
+                .inputName("default")
                 .inputColumnName("default", Arrays.asList(
                         "sepal_length",
                         "sepal_width",
@@ -112,7 +113,7 @@ public class PmmlIrisTest extends BaseVerticleTest {
                         SchemaType.Double,
                         SchemaType.Double,
                 })
-                .outputColumnName("default", Arrays.asList("class"))
+                .outputColumnName("default", Collections.singletonList("class"))
                 .outputSchema("default", new SchemaType[]{SchemaType.String})
                 .build();
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonInput.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonInput.java
@@ -87,8 +87,6 @@ public class TestPythonJsonInput extends BaseMultiNumpyVerticalTest {
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
-                .inputDataFormat(Input.DataFormat.NUMPY)
-                .predictionType(PredictionType.RAW)
                 .build();
 
         InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
@@ -112,7 +110,7 @@ public class TestPythonJsonInput extends BaseMultiNumpyVerticalTest {
         String responseBody = requestSpecification.when()
                 .expect().statusCode(200)
                 .body(not(isEmptyOrNullString()))
-                .post("/raw/dictionary").then()
+                .post("/raw/json").then()
                 .extract()
                 .body().asString();
         JsonArray outputJsonArray = new JsonArray(responseBody);

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonInput.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonInput.java
@@ -23,8 +23,6 @@
 package ai.konduit.serving.verticles.python;
 
 import ai.konduit.serving.InferenceConfiguration;
-import ai.konduit.serving.config.Input;
-import ai.konduit.serving.config.Output.PredictionType;
 import ai.konduit.serving.config.ServingConfig;
 import ai.konduit.serving.model.PythonConfig;
 import ai.konduit.serving.pipeline.step.PythonStep;

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonNdArrayInput.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonNdArrayInput.java
@@ -96,8 +96,6 @@ public class TestPythonJsonNdArrayInput extends BaseMultiNumpyVerticalTest {
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
-                .inputDataFormat(Input.DataFormat.NUMPY)
-                .predictionType(Output.PredictionType.RAW)
                 .build();
 
         InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
@@ -122,7 +120,7 @@ public class TestPythonJsonNdArrayInput extends BaseMultiNumpyVerticalTest {
         String body = requestSpecification.when()
                 .expect().statusCode(200)
                 .body(not(isEmptyOrNullString()))
-                .post("/raw/dictionary").then()
+                .post("/raw/json").then()
                 .extract()
                 .body().asString();
         JsonObject jsonObject1 = new JsonObject(body);

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonNdArrayScalarInput.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonJsonNdArrayScalarInput.java
@@ -93,8 +93,6 @@ public class TestPythonJsonNdArrayScalarInput extends BaseMultiNumpyVerticalTest
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
-                .inputDataFormat(Input.DataFormat.NUMPY)
-                .predictionType(Output.PredictionType.RAW)
                 .build();
 
         InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
@@ -118,7 +116,7 @@ public class TestPythonJsonNdArrayScalarInput extends BaseMultiNumpyVerticalTest
         String body = requestSpecification.when()
                 .expect().statusCode(200)
                 .body(not(isEmptyOrNullString()))
-                .post("/raw/dictionary").then()
+                .post("/raw/json").then()
                 .extract()
                 .body().asString();
         JsonObject jsonObject1 = new JsonObject(body);

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonSetupRun.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonSetupRun.java
@@ -94,8 +94,6 @@ public class TestPythonSetupRun extends BaseMultiNumpyVerticalTest {
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
-                .inputDataFormat(Input.DataFormat.NUMPY)
-                .predictionType(Output.PredictionType.RAW)
                 .build();
 
         InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
@@ -119,7 +117,7 @@ public class TestPythonSetupRun extends BaseMultiNumpyVerticalTest {
         String body = requestSpecification.when()
                 .expect().statusCode(200)
                 .body(not(isEmptyOrNullString()))
-                .post("/raw/dictionary").then()
+                .post("/raw/json").then()
                 .extract()
                 .body().asString();
         JsonObject jsonObject1 = new JsonObject(body);

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/samediff/SameDiffVerticleNd4jTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/samediff/SameDiffVerticleNd4jTest.java
@@ -42,6 +42,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.common.template.test;
 import org.apache.commons.io.FileUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nd4j.autodiff.samediff.SDVariable;
@@ -86,9 +87,7 @@ public class SameDiffVerticleNd4jTest extends BaseVerticleTest {
         SameDiff values = SameDiff.fromFlatFile(tmpSameDiffFile);
 
         ServingConfig servingConfig = ServingConfig.builder()
-                .inputDataFormat(Input.DataFormat.NUMPY)
                 .outputDataFormat(Output.DataFormat.ND4J)
-                .predictionType(PredictionType.RAW)
                 .httpPort(port)
                 .build();
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/samediff/SameDiffVerticleNumpyTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/samediff/SameDiffVerticleNumpyTest.java
@@ -40,6 +40,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.commons.io.FileUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nd4j.autodiff.samediff.SDVariable;
@@ -80,9 +81,7 @@ public class SameDiffVerticleNumpyTest extends BaseVerticleTest {
         sameDiff.asFlatFile(tmpSameDiffFile);
 
         ServingConfig servingConfig = ServingConfig.builder()
-                .inputDataFormat(Input.DataFormat.NUMPY)
                 .outputDataFormat(Output.DataFormat.NUMPY)
-                .predictionType(Output.PredictionType.RAW)
                 .httpPort(port)
                 .build();
 

--- a/python/docs/konduit_cli.md
+++ b/python/docs/konduit_cli.md
@@ -54,8 +54,7 @@ Let's have a look at it first:
 ```yaml
 serving:
   http_port: 1337
-  input_data_type: NUMPY
-  output_data_type: NUMPY
+  output_data_format: NUMPY
   log_timings: True
   extra_start_args: -Xmx8g
   jar_path: konduit.jar

--- a/python/examples/face_detection_pytorch/run_konduit_str.py
+++ b/python/examples/face_detection_pytorch/run_konduit_str.py
@@ -21,7 +21,7 @@ python_config = PythonConfig(
 # for this example.
 python_pipeline_step = PythonStep().step(python_config)
 serving_config = ServingConfig(
-    http_port=1337, input_data_format="JSON", output_data_format="JSON"
+    http_port=1337, output_data_format="JSON"
 )
 
 # Start a konduit server and wait for it to start

--- a/python/examples/pytorch_cifar10/konduit.yml
+++ b/python/examples/pytorch_cifar10/konduit.yml
@@ -1,6 +1,5 @@
 serving:
   http_port: 1337
-  input_data_format: IMAGE
   output_data_format: NUMPY
   log_timings: True
 steps:

--- a/python/examples/pytorch_cifar10/konduit_mnml.yml
+++ b/python/examples/pytorch_cifar10/konduit_mnml.yml
@@ -1,6 +1,5 @@
 serving:
   http_port: 1337
-  input_data_format: IMAGE
   output_data_format: NUMPY
   log_timings: True
 steps:

--- a/python/konduit/base_inference.py
+++ b/python/konduit/base_inference.py
@@ -948,8 +948,6 @@ class PythonConfig(object):
     """
 
     _types_map = {
-        "tensorDataTypesConfig": {"type": TensorDataTypesConfig, "subtype": None},
-        "modelConfigType": {"type": ModelConfigType, "subtype": None},
         "pythonCode": {"type": str, "subtype": None},
         "pythonCodePath": {"type": str, "subtype": None},
         "pythonPath": {"type": str, "subtype": None},
@@ -963,8 +961,6 @@ class PythonConfig(object):
 
     def __init__(
         self,
-        tensor_data_types_config=None,
-        model_config_type=None,
         python_code=None,
         python_code_path=None,
         python_path=None,
@@ -974,8 +970,6 @@ class PythonConfig(object):
         return_all_inputs=None,
         setup_and_run=False,
     ):
-        self.__tensor_data_types_config = tensor_data_types_config
-        self.__model_config_type = model_config_type
         self.__python_code = python_code
         self.__python_code_path = python_code_path
         self.__python_path = python_path
@@ -984,28 +978,6 @@ class PythonConfig(object):
         self.__extra_inputs = extra_inputs
         self.__return_all_inputs = return_all_inputs
         self.__setup_and_run = setup_and_run
-
-    def _get_tensor_data_types_config(self):
-        return self.__tensor_data_types_config
-
-    def _set_tensor_data_types_config(self, value):
-        if not isinstance(value, TensorDataTypesConfig):
-            raise TypeError("tensorDataTypesConfig must be TensorDataTypesConfig")
-        self.__tensor_data_types_config = value
-
-    tensor_data_types_config = property(
-        _get_tensor_data_types_config, _set_tensor_data_types_config
-    )
-
-    def _get_model_config_type(self):
-        return self.__model_config_type
-
-    def _set_model_config_type(self, value):
-        if not isinstance(value, ModelConfigType):
-            raise TypeError("modelConfigType must be ModelConfigType")
-        self.__model_config_type = value
-
-    model_config_type = property(_get_model_config_type, _set_model_config_type)
 
     def _get_python_code(self):
         return self.__python_code
@@ -1101,18 +1073,6 @@ class PythonConfig(object):
 
     def as_dict(self):
         d = empty_type_dict(self)
-        if self.__tensor_data_types_config is not None:
-            d["tensorDataTypesConfig"] = (
-                self.__tensor_data_types_config.as_dict()
-                if hasattr(self.__tensor_data_types_config, "as_dict")
-                else self.__tensor_data_types_config
-            )
-        if self.__model_config_type is not None:
-            d["modelConfigType"] = (
-                self.__model_config_type.as_dict()
-                if hasattr(self.__model_config_type, "as_dict")
-                else self.__model_config_type
-            )
         if self.__python_code is not None:
             d["pythonCode"] = (
                 self.__python_code.as_dict()
@@ -1181,23 +1141,13 @@ class ServingConfig(object):
            extended from Java. don't modify this property.
     """
 
-    _inputDataFormat_enum = enum.Enum(
-        "_inputDataFormat_enum", "NUMPY JSON ND4J IMAGE ARROW", module=__name__
-    )
     _outputDataFormat_enum = enum.Enum(
         "_outputDataFormat_enum", "NUMPY JSON ND4J ARROW", module=__name__
-    )
-    _predictionType_enum = enum.Enum(
-        "_predictionType_enum",
-        "CLASSIFICATION YOLO SSD RCNN RAW REGRESSION",
-        module=__name__,
     )
     _types_map = {
         "httpPort": {"type": int, "subtype": None},
         "listenHost": {"type": str, "subtype": None},
-        "inputDataFormat": {"type": str, "subtype": None},
         "outputDataFormat": {"type": str, "subtype": None},
-        "predictionType": {"type": str, "subtype": None},
         "uploadsDirectory": {"type": str, "subtype": None},
         "logTimings": {"type": bool, "subtype": None},
         "metricTypes": {"type": list, "subtype": str},
@@ -1210,18 +1160,14 @@ class ServingConfig(object):
         self,
         http_port=None,
         listen_host="localhost",
-        input_data_format="NUMPY",
         output_data_format="NUMPY",
-        prediction_type="RAW",
         uploads_directory="file-uploads/",
         log_timings=False,
         metric_types=None,
     ):
         self.__http_port = http_port
         self.__listen_host = listen_host
-        self.__input_data_format = input_data_format
         self.__output_data_format = output_data_format
-        self.__prediction_type = prediction_type
         self.__uploads_directory = uploads_directory
         self.__log_timings = log_timings
         self.__metric_types = metric_types
@@ -1246,19 +1192,6 @@ class ServingConfig(object):
 
     listen_host = property(_get_listen_host, _set_listen_host)
 
-    def _get_input_data_format(self):
-        return self.__input_data_format
-
-    def _set_input_data_format(self, value):
-        if not isinstance(value, str):
-            raise TypeError("inputDataFormat must be str")
-        if value in self._inputDataFormat_enum.__members__:
-            self.__type = value
-        else:
-            raise ValueError("Value {} not in _inputDataFormat_enum list".format(value))
-
-    input_data_format = property(_get_input_data_format, _set_input_data_format)
-
     def _get_output_data_format(self):
         return self.__output_data_format
 
@@ -1273,19 +1206,6 @@ class ServingConfig(object):
             )
 
     output_data_format = property(_get_output_data_format, _set_output_data_format)
-
-    def _get_prediction_type(self):
-        return self.__prediction_type
-
-    def _set_prediction_type(self, value):
-        if not isinstance(value, str):
-            raise TypeError("predictionType must be str")
-        if value in self._predictionType_enum.__members__:
-            self.__type = value
-        else:
-            raise ValueError("Value {} not in _predictionType_enum list".format(value))
-
-    prediction_type = property(_get_prediction_type, _set_prediction_type)
 
     def _get_uploads_directory(self):
         return self.__uploads_directory
@@ -1333,23 +1253,11 @@ class ServingConfig(object):
                 if hasattr(self.__listen_host, "as_dict")
                 else self.__listen_host
             )
-        if self.__input_data_format is not None:
-            d["inputDataFormat"] = (
-                self.__input_data_format.as_dict()
-                if hasattr(self.__input_data_format, "as_dict")
-                else self.__input_data_format
-            )
         if self.__output_data_format is not None:
             d["outputDataFormat"] = (
                 self.__output_data_format.as_dict()
                 if hasattr(self.__output_data_format, "as_dict")
                 else self.__output_data_format
-            )
-        if self.__prediction_type is not None:
-            d["predictionType"] = (
-                self.__prediction_type.as_dict()
-                if hasattr(self.__prediction_type, "as_dict")
-                else self.__prediction_type
             )
         if self.__uploads_directory is not None:
             d["uploadsDirectory"] = (
@@ -1389,47 +1297,33 @@ class PipelineStep(object):
     """
 
     _types_map = {
-        "outputSchemas": {"type": dict, "subtype": None},
         "inputColumnNames": {"type": dict, "subtype": None},
         "outputColumnNames": {"type": dict, "subtype": None},
         "inputSchemas": {"type": dict, "subtype": None},
-        "inputNames": {"type": list, "subtype": str},
+        "outputSchemas": {"type": dict, "subtype": None},
         "outputNames": {"type": list, "subtype": str},
+        "inputNames": {"type": list, "subtype": str},
     }
     _formats_map = {
-        "inputNames": "table",
         "outputNames": "table",
+        "inputNames": "table",
     }
 
     def __init__(
         self,
-        output_schemas=None,
         input_column_names=None,
         output_column_names=None,
         input_schemas=None,
-        input_names=None,
+        output_schemas=None,
         output_names=None,
+        input_names=None,
     ):
-        self.__output_schemas = output_schemas
         self.__input_column_names = input_column_names
         self.__output_column_names = output_column_names
         self.__input_schemas = input_schemas
-        self.__input_names = input_names
+        self.__output_schemas = output_schemas
         self.__output_names = output_names
-
-    def _get_output_schemas(self):
-        return self.__output_schemas
-
-    def _set_output_schemas(self, value):
-        if (
-            not isinstance(value, dict)
-            and not isinstance(value, DictWrapper)
-            and not isinstance(value, DictWrapper)
-        ):
-            raise TypeError("outputSchemas must be type")
-        self.__output_schemas = value
-
-    output_schemas = property(_get_output_schemas, _set_output_schemas)
+        self.__input_names = input_names
 
     def _get_input_column_names(self):
         return self.__input_column_names
@@ -1473,17 +1367,19 @@ class PipelineStep(object):
 
     input_schemas = property(_get_input_schemas, _set_input_schemas)
 
-    def _get_input_names(self):
-        return self.__input_names
+    def _get_output_schemas(self):
+        return self.__output_schemas
 
-    def _set_input_names(self, value):
-        if not isinstance(value, list) and not isinstance(value, ListWrapper):
-            raise TypeError("inputNames must be list")
-        if not all(isinstance(i, str) for i in value):
-            raise TypeError("inputNames list valeus must be str")
-        self.__input_names = value
+    def _set_output_schemas(self, value):
+        if (
+            not isinstance(value, dict)
+            and not isinstance(value, DictWrapper)
+            and not isinstance(value, DictWrapper)
+        ):
+            raise TypeError("outputSchemas must be type")
+        self.__output_schemas = value
 
-    input_names = property(_get_input_names, _set_input_names)
+    output_schemas = property(_get_output_schemas, _set_output_schemas)
 
     def _get_output_names(self):
         return self.__output_names
@@ -1497,14 +1393,20 @@ class PipelineStep(object):
 
     output_names = property(_get_output_names, _set_output_names)
 
+    def _get_input_names(self):
+        return self.__input_names
+
+    def _set_input_names(self, value):
+        if not isinstance(value, list) and not isinstance(value, ListWrapper):
+            raise TypeError("inputNames must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("inputNames list valeus must be str")
+        self.__input_names = value
+
+    input_names = property(_get_input_names, _set_input_names)
+
     def as_dict(self):
         d = empty_type_dict(self)
-        if self.__output_schemas is not None:
-            d["outputSchemas"] = (
-                self.__output_schemas.as_dict()
-                if hasattr(self.__output_schemas, "as_dict")
-                else self.__output_schemas
-            )
         if self.__input_column_names is not None:
             d["inputColumnNames"] = (
                 self.__input_column_names.as_dict()
@@ -1523,13 +1425,19 @@ class PipelineStep(object):
                 if hasattr(self.__input_schemas, "as_dict")
                 else self.__input_schemas
             )
-        if self.__input_names is not None:
-            d["inputNames"] = [
-                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__input_names
-            ]
+        if self.__output_schemas is not None:
+            d["outputSchemas"] = (
+                self.__output_schemas.as_dict()
+                if hasattr(self.__output_schemas, "as_dict")
+                else self.__output_schemas
+            )
         if self.__output_names is not None:
             d["outputNames"] = [
                 p.as_dict() if hasattr(p, "as_dict") else p for p in self.__output_names
+            ]
+        if self.__input_names is not None:
+            d["inputNames"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__input_names
             ]
         return d
 

--- a/python/konduit/base_inference.py
+++ b/python/konduit/base_inference.py
@@ -1132,9 +1132,7 @@ class ServingConfig(object):
 
     :param http_port: HTTP port of the konduit.Server
     :param listen_host: host of the konduit.Server, defaults to 'localhost'
-    :param input_data_format: Input data format, see konduit.Input for more information
     :param output_data_format: Output data format, see konduit.Output for more information
-    :param prediction_type: Prediction type, see konduit.Output for more information
     :param uploads_directory: to which directory to store file uploads to, defaults to 'file-uploads/'
     :param log_timings: whether to log timings for this config, defaults to False
     :param metric_types: the types of metrics logged for your ServingConfig can currently only be configured and

--- a/python/konduit/client.py
+++ b/python/konduit/client.py
@@ -46,7 +46,7 @@ class Client(object):
         url = "{}:{}".format(host, port)
 
         server_running = validate_server(url)
-        insufficient_data = input_data_format is None and output_data_format is None
+        insufficient_data = output_data_format is None
         if server_running:
             try:
                 response = requests.get("{}/config".format(url))
@@ -61,12 +61,8 @@ class Client(object):
                     output_names = []
                     for step in steps:
                         output_names += step["outputNames"]
-                if input_data_format is None:
-                    input_data_format = config["inputDataFormat"]
                 if output_data_format is None:
                     output_data_format = config["outputDataFormat"]
-                if prediction_type is None:
-                    prediction_type = config["predictionType"]
             except Exception as ex:
                 logging.error(
                     "{}\nUnable to get configuration from the server. Please verify that the server is "
@@ -97,6 +93,9 @@ class Client(object):
             self.convert_to_format = output_data_format
         else:
             self.convert_to_format = input_data_format
+
+        if input_data_format is None:
+            input_data_format = "NUMPY"
 
         if prediction_type is None:
             prediction_type = "RAW"

--- a/python/konduit/server.py
+++ b/python/konduit/server.py
@@ -93,7 +93,10 @@ class Server(object):
         else:
             self.extra_jar_args = extra_jar_args
 
-    def get_client(self, output_data_format=None):
+    def get_client(self,
+                   input_data_format=None,
+                   prediction_type=None,
+                   output_data_format=None):
         """Get a Konduit Client instance from this Server instance.
         :param output_data_format: optional, same as in Client signature
         :return: konduit.Client
@@ -110,8 +113,12 @@ class Server(object):
         host = serving_config._get_listen_host()
         if not host.startswith("http://"):
             host = "http://" + host
-        input_data_format = serving_config._get_input_data_format()
-        prediction_type = serving_config._get_prediction_type()
+
+        if not input_data_format:
+            input_data_format = "NUMPY"
+
+        if not prediction_type:
+            prediction_type = "RAW"
 
         if not output_data_format:
             output_data_format = serving_config._get_output_data_format()

--- a/python/tests/test_bert_serving.py
+++ b/python/tests/test_bert_serving.py
@@ -26,7 +26,6 @@ def test_server_start():
     parallel_inference_config = ParallelInferenceConfig(workers=1)
     serving_config = ServingConfig(
         http_port=port,
-        input_data_format="NUMPY",
         output_data_format="NUMPY",
         log_timings=True,
     )
@@ -59,7 +58,7 @@ def test_server_start():
         inference_config=inference, extra_start_args="-Xmx8g", jar_path="konduit.jar"
     )
     server.start()
-    client = Client(input_data_format="NUMPY", prediction_type="NUMPY", port=port)
+    client = Client(input_data_format="NUMPY", prediction_type="RAW", port=port)
 
     data_input = {
         "IteratorGetNext:0": np.load("../data/input-0.npy"),

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -28,7 +28,6 @@ def test_client_from_server():
 def test_multipart_regex():
     client = Client(
         port=1337,
-        input_data_format="NUMPY",
         output_data_format="NUMPY",
         input_names=["partname"],
         output_names=["nobody_cares"],

--- a/python/tests/test_client_serde.py
+++ b/python/tests/test_client_serde.py
@@ -41,7 +41,6 @@ def test_python_serde():
     port = random.randint(1000, 65535)
     serving_config = ServingConfig(
         http_port=port,
-        input_data_format="NUMPY",
         output_data_format="NUMPY",
         log_timings=True,
     )

--- a/python/tests/test_json.py
+++ b/python/tests/test_json.py
@@ -10,8 +10,8 @@ StringJava = autoclass("java.lang.String")
 InferenceConfigurationJava = autoclass("ai.konduit.serving.InferenceConfiguration")
 
 
-#@pytest.mark.unit
-def t2est_json_compare():
+@pytest.mark.unit
+def test_json_compare():
     parallel_inference_config = ParallelInferenceConfig(workers=1)
     serving_config = ServingConfig(
         http_port=1300, output_data_format="NUMPY"
@@ -37,8 +37,8 @@ def t2est_json_compare():
     assert_config_works(inference)
 
 
-#@pytest.mark.unit
-def te2st_python_serde():
+@pytest.mark.unit
+def test_python_serde():
     input_names = ["default"]
     output_names = ["default"]
 
@@ -51,7 +51,6 @@ def te2st_python_serde():
     port = 1300
     serving_config = ServingConfig(
         http_port=port,
-        input_data_format="NUMPY",
         output_data_format="NUMPY",
         log_timings=True,
     )

--- a/python/tests/test_json.py
+++ b/python/tests/test_json.py
@@ -10,11 +10,11 @@ StringJava = autoclass("java.lang.String")
 InferenceConfigurationJava = autoclass("ai.konduit.serving.InferenceConfiguration")
 
 
-@pytest.mark.unit
-def test_json_compare():
+#@pytest.mark.unit
+def t2est_json_compare():
     parallel_inference_config = ParallelInferenceConfig(workers=1)
     serving_config = ServingConfig(
-        http_port=1300, input_data_format="NUMPY", output_data_format="NUMPY"
+        http_port=1300, output_data_format="NUMPY"
     )
 
     tensorflow_config = TensorFlowConfig(
@@ -37,8 +37,8 @@ def test_json_compare():
     assert_config_works(inference)
 
 
-@pytest.mark.unit
-def test_python_serde():
+#@pytest.mark.unit
+def te2st_python_serde():
     input_names = ["default"]
     output_names = ["default"]
 

--- a/python/tests/test_transform_process.py
+++ b/python/tests/test_transform_process.py
@@ -35,7 +35,6 @@ def test_build_tp(output_format):
     port = random.randint(1000, 65535)
     serving_config = ServingConfig(
         http_port=port,
-        input_data_format="JSON",
         output_data_format=output_format,
         log_timings=True,
     )

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -11,6 +11,6 @@ def test_unix_replacement():
 
     step_config = {"python_path": file_path, "bar": 42, "keep_this": file_path}
     unix_step_config = update_dict_with_unix_paths(step_config)
-    assert unix_step_config["python_path"] == "C:/foo/bar:baz"
+    assert unix_step_config["python_path"] == "C:/foo/bar{}baz".format(os.pathsep)
     assert unix_step_config["bar"] == 42
     assert unix_step_config["keep_this"] == file_path

--- a/python/tests/yaml/konduit.yaml
+++ b/python/tests/yaml/konduit.yaml
@@ -1,6 +1,5 @@
 serving:
   http_port: 1337
-  input_data_format: NUMPY
   output_data_format: NUMPY
   log_timings: True
   extra_start_args: -Xmx8g

--- a/python/tests/yaml/konduit_python_code.yaml
+++ b/python/tests/yaml/konduit_python_code.yaml
@@ -1,6 +1,5 @@
 serving:
   http_port: 1337
-  input_data_format: NUMPY
   output_data_format: NUMPY
   log_timings: True
   extra_start_args: -Xmx8g

--- a/python/tests/yaml/konduit_tf_inference.yaml
+++ b/python/tests/yaml/konduit_tf_inference.yaml
@@ -1,6 +1,5 @@
 serving:
   http_port: 1337
-  input_data_format: NUMPY
   output_data_format: NUMPY
   log_timings: True
   extra_start_args: -Xmx8g


### PR DESCRIPTION
I've removed predictionType and inputDataFormat from the serving config since we already specify it through routes. Because of that double specifications, there were confusions of what to specify in the serving config and what to put inside the routes. 