### PR TITLE
TestPythonSetupRun fix

### DIFF
--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonSetupRun.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/python/TestPythonSetupRun.java
@@ -84,7 +84,7 @@ public class TestPythonSetupRun extends BaseMultiNumpyVerticalTest {
     @Override
     public JsonObject getConfigObject() throws Exception {
         PythonConfig pythonConfig = PythonConfig.builder()
-                .pythonCode("def setup(): pass\ndef run(input): return {'output': np.array(input + 2)}")
+                .pythonCode("import numpy as np\ndef setup(): pass\ndef run(input): return {'output': np.array(input + 2)}")
                 .pythonInput("input", PythonVariables.Type.NDARRAY.name())
                 .pythonOutput("output", PythonVariables.Type.NDARRAY.name())
                 .setupAndRun(true)


### PR DESCRIPTION
New python executioner does not import numpy automatically.
