### PR TITLE
Making Konduit-serving architecture more in sync with vertx

### DIFF
--- a/konduit-serving-api/src/main/java/ai/konduit/serving/verticles/base/BaseRoutableVerticle.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/verticles/base/BaseRoutableVerticle.java
@@ -25,7 +25,6 @@ package ai.konduit.serving.verticles.base;
 import ai.konduit.serving.verticles.Routable;
 import ai.konduit.serving.verticles.VerticleConstants;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Context;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
@@ -52,11 +51,6 @@ public abstract class BaseRoutableVerticle extends AbstractVerticle implements R
 
     public BaseRoutableVerticle() {
         super();
-    }
-
-    @Override
-    public void init(Vertx vertx, Context context) {
-        super.init(vertx, context);
     }
 
     /**

--- a/konduit-serving-converter/src/main/java/ai/konduit/serving/input/converter/ConverterVerticle.java
+++ b/konduit-serving-converter/src/main/java/ai/konduit/serving/input/converter/ConverterVerticle.java
@@ -28,9 +28,10 @@ import ai.konduit.serving.input.converter.pmml.SkLearnPmmlHandler;
 import ai.konduit.serving.input.converter.pmml.XgboostPmmlHandler;
 import ai.konduit.serving.input.converter.tensorflow.TensorflowSameDiffHandler;
 import ai.konduit.serving.verticles.base.BaseRoutableVerticle;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
@@ -63,9 +64,9 @@ public class ConverterVerticle extends BaseRoutableVerticle {
     protected String filePath;
     protected String unzipPath;
 
-    @SneakyThrows
     @Override
-    public void start() {
+    public void init(Vertx vertx, Context context) {
+        super.init(vertx, context);
 
         router = Router.router(vertx);
         filePath = config().getString(UPLOAD_KEY) == null ? DEFAULT_UPLOAD_PATH : config().getString(UPLOAD_KEY);
@@ -104,8 +105,5 @@ public class ConverterVerticle extends BaseRoutableVerticle {
                 .failureHandler(failure -> {
                     log.error("Failed to convert ", failure.failure());
                 });
-
-        setupWebServer();
     }
-
 }

--- a/konduit-serving-orchestration/src/main/java/ai/konduit/serving/orchestration/ClusteredInferenceVerticle.java
+++ b/konduit-serving-orchestration/src/main/java/ai/konduit/serving/orchestration/ClusteredInferenceVerticle.java
@@ -23,10 +23,12 @@ package ai.konduit.serving.orchestration;
 
 import ai.konduit.serving.InferenceConfiguration;
 import ai.konduit.serving.configprovider.PipelineRouteDefiner;
+import ai.konduit.serving.verticles.VerticleConstants;
 import ai.konduit.serving.verticles.base.BaseRoutableVerticle;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -47,20 +49,8 @@ import java.util.List;
 @lombok.extern.slf4j.Slf4j
 public class ClusteredInferenceVerticle extends BaseRoutableVerticle {
 
-
     private InferenceConfiguration inferenceConfiguration;
     private ClusterManager clusterManager;
-
-    @Override
-    public void start(Future<Void> startFuture) throws Exception {
-        super.start(startFuture);
-    }
-
-    @Override
-    public void start() throws Exception {
-        super.start();
-
-    }
 
     @Override
     public void stop() throws Exception {
@@ -70,8 +60,8 @@ public class ClusteredInferenceVerticle extends BaseRoutableVerticle {
 
     @Override
     public void init(Vertx vertx, Context context) {
-        this.context = context;
-        this.vertx = vertx;
+        super.init(vertx, context);
+
         inferenceConfiguration = InferenceConfiguration.fromJson(context.config().encode());
         //inference endpoints (pipeline execution, loading,..)
         this.router = new PipelineRouteDefiner().defineRoutes(vertx, inferenceConfiguration);
@@ -89,33 +79,44 @@ public class ClusteredInferenceVerticle extends BaseRoutableVerticle {
             ctx.response().putHeader("Content-Type", "application/json");
             ctx.response().end(new JsonObject().put("nodes", new JsonArray(nodes)).toBuffer());
         });
-
-        setupWebServer();
     }
 
-
-    protected void setupWebServer() {
+    @Override
+    protected void setupWebServer(Promise<Void> startPromise) {
         Preconditions.checkNotNull(inferenceConfiguration, "Inference configuration undefined!");
-        int portValue = inferenceConfiguration.getServingConfig().getHttpPort();
-        if (portValue == 0) {
+        port = inferenceConfiguration.getServingConfig().getHttpPort();
+        if (port == 0) {
             String portEnvValue = System.getenv(ai.konduit.serving.verticles.VerticleConstants.KONDUIT_SERVING_PORT);
             if (portEnvValue != null) {
-                portValue = Integer.parseInt(portEnvValue);
+                try {
+                    port = Integer.parseInt(portEnvValue);
+                } catch (NumberFormatException exception) {
+                    log.error("Environment variable \"{}={}\" isn't a valid port number.", VerticleConstants.KONDUIT_SERVING_PORT, portEnvValue);
+                    startPromise.fail(exception);
+                    return;
+                }
             }
         }
 
-        final int portValueFinal = portValue;
         vertx.createHttpServer()
                 .requestHandler(router)
                 .exceptionHandler(Throwable::printStackTrace)
-                .listen(portValueFinal, inferenceConfiguration.getServingConfig().getListenHost(), listenResult -> {
-                    if (listenResult.failed()) {
-                        log.debug("Could not start HTTP server");
-                        listenResult.cause().printStackTrace();
+                .listen(port, inferenceConfiguration.getServingConfig().getListenHost(), handler -> {
+                    if (handler.failed()) {
+                        log.error("Could not start HTTP server");
+                        startPromise.fail(handler.cause());
                     } else {
-                        log.debug("Server started on port " + portValueFinal);
+                        port = handler.result().actualPort();
+
+                        try {
+                            ((ContextInternal) context).getDeployment().deploymentOptions().setConfig(new JsonObject(inferenceConfiguration.toJson()));
+
+                            log.info("Server started on port {}", port);
+                            startPromise.complete();
+                        } catch (Exception exception) {
+                            startPromise.fail(exception);
+                        }
                     }
                 });
     }
-
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/config/ConfigJsonCoverageTrackingTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/config/ConfigJsonCoverageTrackingTests.java
@@ -51,13 +51,13 @@ public class ConfigJsonCoverageTrackingTests {
         Reflections reflections = new Reflections("ai.konduit");
         Set<Class<? extends TextConfig>> subTypes = reflections.getSubTypesOf(TextConfig.class);
 
-        System.out.println("All subtypes:");
+        System.out.println(String.format("All subtypes of %s:", TextConfig.class.getCanonicalName()));
         for(Class<? extends TextConfig> c : subTypes ){
             int mod = c.getModifiers();
             if(Modifier.isAbstract(mod) || Modifier.isInterface(mod))
                 continue;
             allClasses.add(c);
-//            System.out.println(c);
+            System.out.println(c);
         }
     }
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/PipelineExecutionerTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/executioner/PipelineExecutionerTests.java
@@ -30,6 +30,7 @@ import ai.konduit.serving.pipeline.config.ObjectDetectionConfig;
 import ai.konduit.serving.pipeline.step.ImageLoadingStep;
 import ai.konduit.serving.pipeline.step.ModelStep;
 import ai.konduit.serving.pipeline.step.PythonStep;
+import ai.konduit.serving.util.PortUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import junit.framework.TestCase;
@@ -52,7 +53,7 @@ public class PipelineExecutionerTests {
     @Test
     @Ignore
     public void testDoJsonInference() {
-        int port = 1111;
+        int port = PortUtils.getAvailablePort();
 
         ServingConfig servingConfig = ServingConfig.builder()
                 .httpPort(port)
@@ -166,7 +167,7 @@ public class PipelineExecutionerTests {
     @Test
     public void testInitPipeline() throws Exception {
         ParallelInferenceConfig parallelInferenceConfig = ParallelInferenceConfig.defaultConfig();
-        int port = 1111;
+        int port = PortUtils.getAvailablePort();
         System.out.println("Started on port " + port);
         String path = new ClassPathResource("inference/tensorflow/mnist/lenet_frozen.pb").getFile().getAbsolutePath();
 
@@ -214,7 +215,7 @@ public class PipelineExecutionerTests {
     @Test
     public void testInitPipelineYolo() throws Exception {
         ParallelInferenceConfig parallelInferenceConfig = ParallelInferenceConfig.defaultConfig();
-        int port = 1111;
+        int port = PortUtils.getAvailablePort();
         System.out.println("Started on port " + port);
         String path = new ClassPathResource("inference/tensorflow/mnist/lenet_frozen.pb").getFile().getAbsolutePath();
 

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/input/arrow/BatchInputArrowParserVerticle.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/input/arrow/BatchInputArrowParserVerticle.java
@@ -31,7 +31,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.datavec.api.records.Record;
 import org.nd4j.linalg.api.buffer.DataType;
 
@@ -46,7 +45,6 @@ public class BatchInputArrowParserVerticle extends BaseRoutableVerticle {
     private String inputName = "input1";
     private Record[] batch;
 
-    @SneakyThrows
     @Override
     public void init(Vertx vertx, Context context) {
         super.init(vertx, context);
@@ -59,7 +57,7 @@ public class BatchInputArrowParserVerticle extends BaseRoutableVerticle {
                 .inputParts(Collections.singletonList(inputName))
                 .converters(Collections.singletonMap(inputName, new ArrowBinaryInputAdapter()))
                 .converterArgs(Collections.singletonMap(inputName, ConverterArgs.builder()
-                        .strings(Collections.singletonList(DataType.LONG.name())).build())).build();
+                        .strings(Collections.singletonList(DataType.INT64.name())).build())).build();
         BatchInputArrowParserVerticle.this.inputParser = batchInputParser;
 
 
@@ -73,8 +71,5 @@ public class BatchInputArrowParserVerticle extends BaseRoutableVerticle {
 
             itemHandler.response().end();
         });
-
-        setupWebServer();
     }
-
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/input/arrow/BatchInputParserMultiRecordTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/input/arrow/BatchInputParserMultiRecordTest.java
@@ -48,10 +48,9 @@ import java.io.File;
 import java.util.List;
 
 import static com.jayway.restassured.RestAssured.given;
-import static org.junit.Assert.*;
 
-@RunWith(VertxUnitRunner.class)
 @NotThreadSafe
+@RunWith(VertxUnitRunner.class)
 public class BatchInputParserMultiRecordTest extends BaseVerticleTest {
 
     @Override
@@ -91,9 +90,10 @@ public class BatchInputParserMultiRecordTest extends BaseVerticleTest {
                 .multiPart("input1", tmpFile)
                 .when().post("/")
                 .then().statusCode(200);
-        assertNotNull("Inputs were null. This means parsing failed.", verticleRef.getBatch());
-        assertTrue(verticleRef.getBatch().length >= 1);
-        assertNotNull(verticleRef.getBatch());
-        assertEquals(150, verticleRef.getBatch().length);
+
+        testContext.assertNotNull(verticleRef.getBatch(), "Inputs were null. This means parsing failed.");
+        testContext.assertTrue(verticleRef.getBatch().length >= 1);
+        testContext.assertNotNull(verticleRef.getBatch());
+        testContext.assertEquals(150, verticleRef.getBatch().length);
     }
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/input/image/BatchInputParserVerticle.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/input/image/BatchInputParserVerticle.java
@@ -31,7 +31,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.datavec.api.records.Record;
 import org.nd4j.linalg.api.buffer.DataType;
 
@@ -46,7 +45,6 @@ public class BatchInputParserVerticle extends BaseRoutableVerticle {
     private String inputName = "input1";
     private Record[] batch;
 
-    @SneakyThrows
     @Override
     public void init(Vertx vertx, Context context) {
         super.init(vertx, context);
@@ -73,8 +71,5 @@ public class BatchInputParserVerticle extends BaseRoutableVerticle {
 
             itemHandler.response().end();
         });
-
-        setupWebServer();
     }
-
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/input/nd4j/BatchNd4jInputParserVerticle.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/input/nd4j/BatchNd4jInputParserVerticle.java
@@ -31,7 +31,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.datavec.api.records.Record;
 import org.nd4j.linalg.api.buffer.DataType;
 
@@ -46,7 +45,6 @@ public class BatchNd4jInputParserVerticle extends BaseRoutableVerticle {
     private String inputName = "input1";
     private Record[] batch;
 
-    @SneakyThrows
     @Override
     public void init(Vertx vertx, Context context) {
         super.init(vertx, context);
@@ -73,8 +71,5 @@ public class BatchNd4jInputParserVerticle extends BaseRoutableVerticle {
 
             itemHandler.response().end();
         });
-
-        setupWebServer();
     }
-
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/input/numpy/BatchNumpyInputParserVerticle.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/input/numpy/BatchNumpyInputParserVerticle.java
@@ -31,7 +31,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.datavec.api.records.Record;
 import org.nd4j.linalg.api.buffer.DataType;
 
@@ -46,7 +45,6 @@ public class BatchNumpyInputParserVerticle extends BaseRoutableVerticle {
     private String inputName = "input1";
     private Record[] batch;
 
-    @SneakyThrows
     @Override
     public void init(Vertx vertx, Context context) {
         super.init(vertx, context);
@@ -73,8 +71,5 @@ public class BatchNumpyInputParserVerticle extends BaseRoutableVerticle {
 
             itemHandler.response().end();
         });
-
-        setupWebServer();
     }
-
 }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/orchestration/KonduitOrchestrationMainTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/orchestration/KonduitOrchestrationMainTest.java
@@ -53,23 +53,24 @@ public class KonduitOrchestrationMainTest {
                 .configPath(tmpFile.getAbsolutePath())
                 .build();
         KonduitOrchestrationMain.builder()
-                .onSuccess(() -> {
-                    try {
-                        Response response = given().port(port)
-                                .get("/nodes")
-                                .then()
-                                .statusCode(200).and()
-                                .contentType("application/json")
-                                .extract().response();
-                        System.out.println(response.body().prettyPrint());
+                .eventHandler(handler -> {
+                    if(handler.succeeded()) {
+                        try {
+                            Response response = given().port(port)
+                                    .get("/nodes")
+                                    .then()
+                                    .statusCode(200).and()
+                                    .contentType("application/json")
+                                    .extract().response();
+                            System.out.println(response.body().prettyPrint());
 
-                        async.complete();
-                    } catch (Exception e) {
-                        testContext.fail("Orchestration main server failed to start." + e);
+                            async.complete();
+                        } catch (Exception e) {
+                            testContext.fail("Orchestration main server failed to start." + e);
+                        }
+                    } else {
+                        testContext.fail("Orchestration main server failed to start.");
                     }
-                })
-                .onFailure(() -> {
-                    testContext.fail("Orchestration main server failed to start.");
                 })
                 .build()
                 .runMain(configurer);

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/util/PortsTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/util/PortsTest.java
@@ -85,18 +85,23 @@ public class PortsTest {
                 .build();
 
         KonduitServingMain.builder()
-                .onSuccess(port -> {
-                    testContext.assertTrue(port > 0 && port <= 0xFFFF);
+                .eventHandler(handler -> {
+                    if(handler.succeeded()) {
+                        int port = handler.result().getServingConfig().getHttpPort();
 
-                    // Health checking
-                    given().port(port)
-                            .get("/healthcheck")
-                            .then()
-                            .statusCode(204);
+                        testContext.assertTrue(port > 0 && port <= 0xFFFF);
 
-                    async.complete();
+                        // Health checking
+                        given().port(port)
+                                .get("/healthcheck")
+                                .then()
+                                .statusCode(204);
+
+                        async.complete();
+                    } else {
+                        testContext.fail(handler.cause());
+                    }
                 })
-                .onFailure(testContext::fail)
                 .build()
                 .runMain(args.toArgs());
     }
@@ -113,26 +118,29 @@ public class PortsTest {
                 .build();
 
         KonduitServingMain konduitServingMain = KonduitServingMain.builder().build();
-        konduitServingMain.setOnSuccess(port -> {
-                    testContext.assertTrue(port > 0 && port <= 0xFFFF);
+        konduitServingMain.setEventHandler(handler -> {
+            if (handler.succeeded()) {
+                int port = handler.result().getServingConfig().getHttpPort();
 
-                    // Health checking
-                    given().port(port)
-                            .get("/healthcheck")
-                            .then()
-                            .statusCode(204);
+                testContext.assertTrue(port > 0 && port <= 0xFFFF);
 
-                    konduitServingMain.runMain(args.toArgs());
-                    async.countDown();
-                });
+                // Health checking
+                given().port(port)
+                        .get("/healthcheck")
+                        .then()
+                        .statusCode(204);
 
-        konduitServingMain.setOnFailure(throwable -> {
-                    if(throwable instanceof BindException &&
+                konduitServingMain.runMain(args.toArgs());
+                async.countDown();
+            } else {
+                Throwable throwable = handler.cause();
+                if(throwable instanceof BindException &&
                         throwable.getMessage().contains("Address already in use")) {
-                        async.countDown();
-                    } else {
-                        testContext.fail(throwable);
-                    }
+                    async.countDown();
+                } else {
+                    testContext.fail(throwable);
+                }
+            }
         });
 
         konduitServingMain.runMain(args.toArgs());
@@ -150,22 +158,27 @@ public class PortsTest {
                 .configStoreType("file").ha(false)
                 .multiThreaded(false)
                 .verticleClassName(InferenceVerticle.class.getName())
-                .configPath(getConfig(testContext, -1))  // this port number will be ignored in this case
+                .configPath(getConfig(testContext, -1))  // this port number will be ignored in this case because the port value will be taken from the environment VerticleConstants#KONDUIT_SERVING_PORT
                 .build();
 
         KonduitServingMain.builder()
-                .onSuccess(port -> {
-                    testContext.assertEquals(port, selectedPort);
+                .eventHandler(handler -> {
+                    if(handler.succeeded()) {
+                        int port = handler.result().getServingConfig().getHttpPort();
 
-                    // Health checking
-                    given().port(selectedPort)
-                            .get("/healthcheck")
-                            .then()
-                            .statusCode(204);
+                        testContext.assertEquals(port, selectedPort);
 
-                    async.complete();
+                        // Health checking
+                        given().port(selectedPort)
+                                .get("/healthcheck")
+                                .then()
+                                .statusCode(204);
+
+                        async.complete();
+                    } else {
+                        testContext.fail(handler.cause());
+                    }
                 })
-                .onFailure(testContext::fail)
                 .build()
                 .runMain(args.toArgs());
     }
@@ -186,18 +199,23 @@ public class PortsTest {
                     .configStoreType("file").ha(false)
                     .multiThreaded(false)
                     .verticleClassName(InferenceVerticle.class.getName())
-                    .configPath(getConfig(testContext, -1)) // this port number will be ignored in this case
+                    .configPath(getConfig(testContext, -1)) // this port number will be ignored in this case because the port value will be taken from the environment VerticleConstants#KONDUIT_SERVING_PORT
                     .build();
 
             KonduitServingMain.builder()
-                    .onSuccess(port -> testContext.fail(String.format("onSuccess hook was called with port value: %s", invalidPorts[finalI])))
-                    .onFailure(throwable -> {
-                        String throwableMessage = throwable.getMessage();
-                        if(throwableMessage.contains(String.format("Valid port range is between 0-65535. The given port was %s", invalidPorts[finalI])) ||
-                            throwableMessage.contains(String.format("For input string: \"%s\"", invalidPorts[finalI]))) {
-                            asyncs[finalI].complete();
+                    .eventHandler(handler -> {
+                        if(handler.succeeded()) {
+                            testContext.fail(String.format("Success event called with port value: %s", invalidPorts[finalI]));
                         } else {
-                            testContext.fail(throwable);
+                            Throwable throwable = handler.cause();
+
+                            String throwableMessage = throwable.getMessage();
+                            if(throwableMessage.contains(String.format("Valid port range is 0 <= port <= 65535. The given port was %s", invalidPorts[finalI])) ||
+                                    throwableMessage.contains(String.format("For input string: \"%s\"", invalidPorts[finalI]))) {
+                                asyncs[finalI].complete();
+                            } else {
+                                testContext.fail(throwable);
+                            }
                         }
                     })
                     .build()
@@ -221,18 +239,23 @@ public class PortsTest {
                 .build();
 
         KonduitServingMain.builder()
-                .onSuccess(port -> {
-                    testContext.assertEquals(port, selectedPort);
+                .eventHandler(handler -> {
+                    if(handler.succeeded()) {
+                        int port = handler.result().getServingConfig().getHttpPort();
 
-                    // Health checking
-                    given().port(selectedPort)
-                            .get("/healthcheck")
-                            .then()
-                            .statusCode(204);
+                        testContext.assertEquals(port, selectedPort);
 
-                    async.complete();
+                        // Health checking
+                        given().port(selectedPort)
+                                .get("/healthcheck")
+                                .then()
+                                .statusCode(204);
+
+                        async.complete();
+                    } else {
+                        testContext.fail(handler.cause());
+                    }
                 })
-                .onFailure(testContext::fail)
                 .build()
                 .runMain(args.toArgs());
     }

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/util/PortsTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/util/PortsTest.java
@@ -128,7 +128,7 @@ public class PortsTest {
 
         konduitServingMain.setOnFailure(throwable -> {
                     if(throwable instanceof BindException &&
-                        throwable.getMessage().equalsIgnoreCase("Address already in use")) {
+                        throwable.getMessage().contains("Address already in use")) {
                         async.countDown();
                     } else {
                         testContext.fail(throwable);

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/BaseVerticleTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/verticles/BaseVerticleTest.java
@@ -22,6 +22,7 @@
 
 package ai.konduit.serving.verticles;
 
+import ai.konduit.serving.util.PortUtils;
 import io.vertx.core.*;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
@@ -37,8 +38,6 @@ import org.nd4j.linalg.api.memory.enums.DebugMode;
 import org.nd4j.linalg.factory.Nd4j;
 
 import javax.annotation.concurrent.NotThreadSafe;
-import java.io.IOException;
-import java.net.ServerSocket;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -59,8 +58,8 @@ public abstract class BaseVerticleTest {
 
     @Before
     public void before(TestContext context) throws Exception {
-        port = getRandomPort();
-        pubsubPort = getRandomPort();
+        port = PortUtils.getAvailablePort();
+        pubsubPort = PortUtils.getAvailablePort();
         System.setProperty("vertx.options.maxEventLoopExecuteTime", "240000");
         VertxOptions vertxOptions = new VertxOptions();
         vertxOptions.setMaxEventLoopExecuteTime(240000);
@@ -116,13 +115,6 @@ public abstract class BaseVerticleTest {
         return ai.konduit.serving.verticles.inference.InferenceVerticle.class;
     }
 
-    public int getRandomPort() throws IOException {
-        ServerSocket pubSubSocket = new ServerSocket(0);
-        int ret = pubSubSocket.getLocalPort();
-        pubSubSocket.close();
-        return ret;
-    }
-
     public abstract Handler<HttpServerRequest> getRequest();
 
     public abstract JsonObject getConfigObject() throws Exception;
@@ -132,5 +124,4 @@ public abstract class BaseVerticleTest {
     public boolean isPubSub() {
         return false;
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependencies>
             <dependency>
                 <groupId>com.google.guava</groupId>
-                <artifactId>:guava</artifactId>
+                <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,10 +139,16 @@
         <reflections.version>0.9.10</reflections.version>
 
         <oshi.version>3.13.4</oshi.version>
+        <guava.version>20.0</guava.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>:guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.github.oshi</groupId>
                 <artifactId>oshi-core</artifactId>


### PR DESCRIPTION
Previously I had to use `@SneakyThrows` to bypass some of the compiler checks. This PR takes care of that. Also, it utilizes more of what vertx offers to make the konduit-serving architecture more in sync with how vertx works. Tests run a bit faster now and the APIs are easier to use. Callbacks make more sense and easy to extend.

By doing this we can also make better use of VertxShell since it depends a lot on the application being used how vertx expects it to. 