### PR TITLE
Change classification metrics to reset upon export

### DIFF
--- a/konduit-serving-api/src/main/java/ai/konduit/serving/config/metrics/impl/MultiLabelMetricsConfig.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/config/metrics/impl/MultiLabelMetricsConfig.java
@@ -44,6 +44,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class MultiLabelMetricsConfig implements MetricsConfig {
     @Getter
     private List<String> labels;

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/config/metrics/impl/MultiLabelMetricsConfig.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/config/metrics/impl/MultiLabelMetricsConfig.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  * ******************************************************************************
+ *  *  * Copyright (c) 2015-2019 Skymind Inc.
+ *  *  * Copyright (c) 2019 Konduit AI.
+ *  *  *
+ *  *  * This program and the accompanying materials are made available under the
+ *  *  * terms of the Apache License, Version 2.0 which is available at
+ *  *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  *  * License for the specific language governing permissions and limitations
+ *  *  * under the License.
+ *  *  *
+ *  *  * SPDX-License-Identifier: Apache-2.0
+ *  *  *****************************************************************************
+ *
+ *
+ */
+package ai.konduit.serving.config.metrics.impl;
+
+import ai.konduit.serving.config.metrics.MetricsConfig;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import lombok.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A metrics configuration for a metrics render
+ * that, given a set of specified labels
+ * takes in counts of columns to increment.
+ * The input is either a matrix or a vector representing the columns
+ * to increment the count by. The column counts should be the same order
+ * as the specified labels for this configuration.
+ *
+ * @author Adam Gibson
+ */
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MultiLabelMetricsConfig implements MetricsConfig {
+    @Getter
+    private List<String> labels;
+
+    @SneakyThrows
+    @Override
+    public Class<? extends MeterBinder> metricsBinderImplementation() {
+        return (Class<? extends MeterBinder>) Class.forName("ai.konduit.serving.metrics.MultiLabelMetrics");
+    }
+
+    @Override
+    public Map<String, Object> configValues() {
+        return Collections.singletonMap("labels",labels);
+    }
+}

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/config/metrics/impl/MultiLabelMetricsConfig.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/config/metrics/impl/MultiLabelMetricsConfig.java
@@ -22,6 +22,7 @@
 package ai.konduit.serving.config.metrics.impl;
 
 import ai.konduit.serving.config.metrics.MetricsConfig;
+import ai.konduit.serving.util.ObjectMappers;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import lombok.*;
 
@@ -57,4 +58,14 @@ public class MultiLabelMetricsConfig implements MetricsConfig {
     public Map<String, Object> configValues() {
         return Collections.singletonMap("labels",labels);
     }
+
+
+    public static MultiLabelMetricsConfig fromJson(String json) {
+        return ObjectMappers.fromJson(json, MultiLabelMetricsConfig.class);
+    }
+
+    public static MultiLabelMetricsConfig fromYaml(String yaml) {
+        return ObjectMappers.fromYaml(yaml, MultiLabelMetricsConfig.class);
+    }
+
 }

--- a/konduit-serving-api/src/main/java/ai/konduit/serving/metrics/MetricType.java
+++ b/konduit-serving-api/src/main/java/ai/konduit/serving/metrics/MetricType.java
@@ -40,5 +40,6 @@ public enum MetricType {
     //these are meant to analyze the output coming form the neural network when running
     //in production
     CLASSIFICATION,
-    REGRESSION
+    REGRESSION,
+    CUSTOM_MULTI_LABEL
 }

--- a/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
+++ b/konduit-serving-codegen/src/main/java/ai/konduit/serving/codegen/pythoncodegen/CodeGen.java
@@ -26,7 +26,9 @@ import ai.konduit.serving.InferenceConfiguration;
 import ai.konduit.serving.config.*;
 import ai.konduit.serving.config.metrics.NoOpMetricsConfig;
 import ai.konduit.serving.config.metrics.impl.ClassificationMetricsConfig;
+import ai.konduit.serving.config.metrics.impl.MultiLabelMetricsConfig;
 import ai.konduit.serving.config.metrics.impl.RegressionMetricsConfig;
+import ai.konduit.serving.metrics.MultiLabelMetrics;
 import ai.konduit.serving.metrics.RegressionMetrics;
 import ai.konduit.serving.model.*;
 import ai.konduit.serving.pipeline.BasePipelineStep;
@@ -62,6 +64,7 @@ public class CodeGen {
         JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, JsonSchemaConfig.html5EnabledSchema());
 
         Set<Class<?>> clazzes = new LinkedHashSet();
+        clazzes.add(MultiLabelMetricsConfig.class);
         clazzes.add(NoOpMetricsConfig.class);
         clazzes.add(ClassificationMetricsConfig.class);
         clazzes.add(RegressionMetricsConfig.class);

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/configprovider/PipelineRouteDefiner.java
@@ -31,14 +31,12 @@ import ai.konduit.serving.config.metrics.MetricsConfig;
 import ai.konduit.serving.config.metrics.MetricsRenderer;
 import ai.konduit.serving.config.metrics.impl.ClassificationMetricsConfig;
 import ai.konduit.serving.config.metrics.impl.MetricsBinderRendererAdapter;
+import ai.konduit.serving.config.metrics.impl.MultiLabelMetricsConfig;
 import ai.konduit.serving.config.metrics.impl.RegressionMetricsConfig;
 import ai.konduit.serving.executioner.PipelineExecutioner;
 import ai.konduit.serving.input.adapter.InputAdapter;
 import ai.konduit.serving.input.conversion.BatchInputParser;
-import ai.konduit.serving.metrics.ClassificationMetrics;
-import ai.konduit.serving.metrics.MetricType;
-import ai.konduit.serving.metrics.NativeMetrics;
-import ai.konduit.serving.metrics.RegressionMetrics;
+import ai.konduit.serving.metrics.*;
 import ai.konduit.serving.pipeline.PipelineStep;
 import ai.konduit.serving.pipeline.handlers.converter.JsonArrayMapConverter;
 import ai.konduit.serving.pipeline.handlers.converter.multi.converter.impl.arrow.ArrowBinaryInputAdapter;
@@ -223,6 +221,27 @@ public class PipelineRouteDefiner {
                             }
 
                         }
+                        break;
+                    case CUSTOM_MULTI_LABEL:
+                        if(inferenceConfiguration.getServingConfig().getMetricsConfigurations() == null) {
+                            throw new IllegalStateException("Please specify classification labels to pair with regression metrics");
+                        }
+
+                        List<MetricsConfig> metricsConfigurations3 = inferenceConfiguration.getServingConfig().getMetricsConfigurations();
+                        for(MetricsConfig metricsConfig : metricsConfigurations3) {
+                            if(metricsConfig instanceof MultiLabelMetricsConfig) {
+                                MultiLabelMetricsConfig multiLabelMetricsConfig = (MultiLabelMetricsConfig) metricsConfig;
+                                if(multiLabelMetricsConfig.getLabels() == null || multiLabelMetricsConfig.getLabels().isEmpty()) {
+                                    throw new IllegalStateException("No  labels configured for the regression metrics configuration. Please specify labels.");
+                                }
+
+                                MultiLabelMetrics regressionMetrics = new MultiLabelMetrics(multiLabelMetricsConfig);
+                                regressionMetrics.bindTo(registry);
+                                metricsRenderers.add(regressionMetrics);
+                            }
+
+                        }
+
                         break;
 
                     case GPU:

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/ClassificationMetrics.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/ClassificationMetrics.java
@@ -26,6 +26,7 @@ import ai.konduit.serving.config.metrics.MetricsConfig;
 import ai.konduit.serving.config.metrics.MetricsRenderer;
 import ai.konduit.serving.config.metrics.impl.ClassificationMetricsConfig;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import lombok.Getter;
@@ -36,6 +37,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.AtomicDouble;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -56,7 +58,7 @@ public class ClassificationMetrics implements MetricsRenderer {
     private ClassificationMetricsConfig classificationMetricsConfig;
 
     public ClassificationMetrics(ClassificationMetricsConfig classificationMetricsConfig) {
-        this(classificationMetricsConfig, Collections.emptyList());
+        this(classificationMetricsConfig, Arrays.asList(new ImmutableTag("machinelearning","classification")));
     }
 
     public ClassificationMetrics(ClassificationMetricsConfig classificationMetricsConfig, Iterable<Tag> tags) {

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/ClassificationMetrics.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/ClassificationMetrics.java
@@ -51,6 +51,7 @@ public class ClassificationMetrics implements MetricsRenderer {
     private Iterable<Tag> tags;
     @Getter
     private List<Gauge> classCounterIncrement;
+    @Getter
     private List<CurrentClassTrackerCount> classTrackerCounts;
     private ClassificationMetricsConfig classificationMetricsConfig;
 
@@ -135,22 +136,22 @@ public class ClassificationMetrics implements MetricsRenderer {
 
 
     private void incrementClassificationCounters(INDArray[] outputs) {
-        INDArray argMax = Nd4j.argMax(outputs[0], -1);
-        for(int i = 0; i < argMax.length(); i++) {
-            CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(argMax.getInt(i));
-            classTrackerCount.increment(1.0);
-        }
+        handleNdArray(outputs[0]);
     }
 
     private void incrementClassificationCounters(Record[] records) {
         if(classCounterIncrement != null) {
             NDArrayWritable ndArrayWritable = (NDArrayWritable) records[0].getRecord().get(0);
             INDArray output = ndArrayWritable.get();
-            INDArray argMax = Nd4j.argMax(output, -1);
-            for (int i = 0; i < argMax.length(); i++) {
-                CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(argMax.getInt(i));
-                classTrackerCount.increment(1.0);
-            }
+            handleNdArray(output);
+        }
+    }
+
+    private void handleNdArray(INDArray array) {
+        INDArray argMax = Nd4j.argMax(array, -1);
+        for(int i = 0; i < argMax.length(); i++) {
+            CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(argMax.getInt(i));
+            classTrackerCount.increment(1.0);
         }
     }
 }

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/MultiLabelMetrics.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/MultiLabelMetrics.java
@@ -25,6 +25,7 @@ import ai.konduit.serving.config.metrics.MetricsConfig;
 import ai.konduit.serving.config.metrics.MetricsRenderer;
 import ai.konduit.serving.config.metrics.impl.MultiLabelMetricsConfig;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import lombok.Getter;
@@ -35,6 +36,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.AtomicDouble;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -68,7 +70,7 @@ public class MultiLabelMetrics implements MetricsRenderer {
     }
 
     public MultiLabelMetrics(MultiLabelMetricsConfig multiLabelMetricsConfig) {
-        this(multiLabelMetricsConfig, Collections.emptyList());
+        this(multiLabelMetricsConfig, Arrays.asList(new ImmutableTag("machinelearning","multilabel")));
     }
     @Override
     public MetricsConfig config() {

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/MultiLabelMetrics.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/MultiLabelMetrics.java
@@ -1,0 +1,185 @@
+/*
+ *
+ *  * ******************************************************************************
+ *  *  * Copyright (c) 2015-2019 Skymind Inc.
+ *  *  * Copyright (c) 2019 Konduit AI.
+ *  *  *
+ *  *  * This program and the accompanying materials are made available under the
+ *  *  * terms of the Apache License, Version 2.0 which is available at
+ *  *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  *  * License for the specific language governing permissions and limitations
+ *  *  * under the License.
+ *  *  *
+ *  *  * SPDX-License-Identifier: Apache-2.0
+ *  *  *****************************************************************************
+ *
+ *
+ */
+package ai.konduit.serving.metrics;
+
+import ai.konduit.serving.config.metrics.MetricsConfig;
+import ai.konduit.serving.config.metrics.MetricsRenderer;
+import ai.konduit.serving.config.metrics.impl.MultiLabelMetricsConfig;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.Getter;
+import org.datavec.api.records.Record;
+import org.datavec.api.writable.NDArrayWritable;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.AtomicDouble;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A {@link MetricsRenderer} that takes in matrices of counts
+ * where each column (indexed by what is specified in the {@link #multiLabelMetricsConfig}
+ * specified in {@link #updateMetrics(Object...)}
+ * is a count of how to increment the column.
+ *
+ * Note that similar to {@link ClassificationMetrics}
+ * the counts will reset upon sampling via prometheus.
+ *
+ * @author Adam Gibson
+ */
+public class MultiLabelMetrics implements MetricsRenderer {
+    @Getter
+    private MultiLabelMetricsConfig multiLabelMetricsConfig;
+    @Getter
+    private List<CurrentClassTrackerCount> classTrackerCounts;
+
+    private Iterable<Tag> tags;
+    @Getter
+    private List<Gauge> classCounterIncrement;
+
+    public MultiLabelMetrics(MultiLabelMetricsConfig multiLabelMetricsConfig, Iterable<Tag> tags) {
+        this.multiLabelMetricsConfig = multiLabelMetricsConfig;
+        this.tags = tags;
+        classTrackerCounts = new ArrayList<>();
+        classCounterIncrement = new ArrayList<>();
+    }
+
+    public MultiLabelMetrics(MultiLabelMetricsConfig multiLabelMetricsConfig) {
+        this(multiLabelMetricsConfig, Collections.emptyList());
+    }
+    @Override
+    public MetricsConfig config() {
+        return multiLabelMetricsConfig;
+    }
+
+
+    @Override
+    public void updateMetrics(Object... args) {
+        if(args[0] instanceof Record) {
+            Record records = (Record) args[0];
+            incrementClassificationCounters(new Record[]{records});
+        }
+        else if(args[0] instanceof Record[]) {
+            Record[] records = (Record[]) args[0];
+            incrementClassificationCounters(records);
+        }
+        else if(args[0] instanceof INDArray) {
+            INDArray output = (INDArray) args[0];
+            incrementClassificationCounters(new INDArray[] {output});
+        }
+        else if(args[0] instanceof INDArray[]) {
+            INDArray[] output = (INDArray[]) args[0];
+            incrementClassificationCounters(output);
+
+        }
+    }
+
+    private void incrementClassificationCounters(INDArray[] outputs) {
+        INDArray argMax = Nd4j.argMax(outputs[0], -1);
+        for(int i = 0; i < argMax.length(); i++) {
+            CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(argMax.getInt(i));
+            classTrackerCount.increment(1.0);
+        }
+    }
+
+    private void incrementClassificationCounters(Record[] records) {
+        if(classCounterIncrement != null) {
+            NDArrayWritable ndArrayWritable = (NDArrayWritable) records[0].getRecord().get(0);
+            INDArray output = ndArrayWritable.get();
+            INDArray argMax = Nd4j.argMax(output, -1);
+            for (int i = 0; i < argMax.length(); i++) {
+                CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(argMax.getInt(i));
+                classTrackerCount.increment(1.0);
+            }
+        }
+    }
+
+    private void handleNdArray(INDArray array) {
+
+        if(array.isScalar()) {
+            CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(0);
+            classTrackerCount.increment(array.getDouble(0));
+
+        }
+        else if(array.isMatrix()) {
+            for(int i = 0; i < array.rows(); i++) {
+                for(int j = 0; j < array.columns(); j++) {
+                    CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(array.getInt(i));
+                    classTrackerCount.increment(array.getDouble(i,j));
+
+                }
+            }
+        }
+        else if(array.isVector()) {
+            for (int i = 0; i < array.length(); i++) {
+                CurrentClassTrackerCount classTrackerCount = classTrackerCounts.get(array.getInt(i));
+                classTrackerCount.increment(array.getDouble(i));
+            }
+        }
+
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for(int i = 0; i < multiLabelMetricsConfig.getLabels().size(); i++) {
+            CurrentClassTrackerCount classTrackerCount = new CurrentClassTrackerCount();
+            classTrackerCounts.add(classTrackerCount);
+            classCounterIncrement.add(Gauge.builder(multiLabelMetricsConfig.getLabels().get(i),classTrackerCount)
+                    .tags(tags)
+                    .description("Multi-label Classification counts seen so far for label " + multiLabelMetricsConfig.getLabels().get(i))
+                    .baseUnit("multilabelclassification.outcome")
+                    .register(registry));
+
+
+        }
+    }
+
+    /**
+     * A counter that resets the in memory value when
+     * the metric is exported. It is assumed that when exported,
+     * a storage system captures the sampled value.
+     *
+     */
+    private static class CurrentClassTrackerCount implements Supplier<Number> {
+
+        private AtomicDouble currCounter = new AtomicDouble(0);
+
+        public void increment(double numberToIncrementBy) {
+            currCounter.getAndAdd(numberToIncrementBy);
+        }
+
+        public void reset() {
+            currCounter.set(0.0);
+        }
+
+        @Override
+        public Number get() { ;
+            double ret = currCounter.get();
+            reset();
+            return ret;
+        }
+    }
+}

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/RegressionMetrics.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/RegressionMetrics.java
@@ -28,6 +28,7 @@ import ai.konduit.serving.config.metrics.MetricsRenderer;
 import ai.konduit.serving.config.metrics.impl.RegressionMetricsConfig;
 import ai.konduit.serving.util.MetricRenderUtils;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import lombok.Getter;
@@ -38,6 +39,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -57,7 +59,7 @@ public class RegressionMetrics implements MetricsRenderer {
     private RegressionMetricsConfig regressionMetricsConfig;
 
     public RegressionMetrics(RegressionMetricsConfig regressionMetricsConfig) {
-        this(regressionMetricsConfig, Collections.emptyList());
+        this(regressionMetricsConfig, Arrays.asList(new ImmutableTag("machinelearning","regression")));
     }
 
     public RegressionMetrics(RegressionMetricsConfig regressionMetricsConfig, Iterable<Tag> tags) {

--- a/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/RegressionMetrics.java
+++ b/konduit-serving-core/src/main/java/ai/konduit/serving/metrics/RegressionMetrics.java
@@ -40,7 +40,6 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -147,26 +146,34 @@ public class RegressionMetrics implements MetricsRenderer {
 
     @Override
     public void updateMetrics(Object... args) {
-        if(args instanceof Record[]) {
-            Record[] records = (Record[]) args;
-            incrementClassificationCounters(records);
+        if(args[0] instanceof Record) {
+            Record records = (Record) args[0];
+            incrementRegressionCounters(new Record[]{records});
         }
-        else if(args instanceof INDArray[]) {
-            INDArray[] output = (INDArray[]) args;
-            incrementClassificationCounters(output);
+        else if(args[0] instanceof Record[]) {
+            Record[] records = (Record[]) args[0];
+            incrementRegressionCounters(records);
+        }
+        else if(args[0] instanceof INDArray) {
+            INDArray output = (INDArray) args[0];
+            incrementRegressionCounters(new INDArray[] {output});
+        }
+        else if(args[0] instanceof INDArray[]) {
+            INDArray[] output = (INDArray[]) args[0];
+            incrementRegressionCounters(output);
 
         }
     }
 
 
-    private void incrementClassificationCounters(INDArray[] outputs) {
+    private void incrementRegressionCounters(INDArray[] outputs) {
         synchronized (statCounters) {
             handleNdArray(outputs[0]);
         }
 
     }
 
-    private void incrementClassificationCounters(Record[] records) {
+    private void incrementRegressionCounters(Record[] records) {
         synchronized (statCounters) {
             NDArrayWritable ndArrayWritable = (NDArrayWritable) records[0].getRecord().get(0);
             handleNdArray(ndArrayWritable.get());

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/config/ConfigJsonCoverageTrackingTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/config/ConfigJsonCoverageTrackingTests.java
@@ -19,8 +19,10 @@ import ai.konduit.serving.InferenceConfiguration;
 import ai.konduit.serving.config.metrics.ColumnDistribution;
 import ai.konduit.serving.config.metrics.NoOpMetricsConfig;
 import ai.konduit.serving.config.metrics.impl.ClassificationMetricsConfig;
+import ai.konduit.serving.config.metrics.impl.MultiLabelMetricsConfig;
 import ai.konduit.serving.config.metrics.impl.RegressionMetricsConfig;
 import ai.konduit.serving.metrics.MetricType;
+import ai.konduit.serving.metrics.MultiLabelMetrics;
 import ai.konduit.serving.model.*;
 import ai.konduit.serving.pipeline.config.ObjectDetectionConfig;
 import ai.konduit.serving.pipeline.step.*;
@@ -237,6 +239,8 @@ public class ConfigJsonCoverageTrackingTests {
         testConfigSerDe(ColumnDistribution.builder().build());
         testConfigSerDe(NoOpMetricsConfig
                 .builder().build());
+        testConfigSerDe(MultiLabelMetricsConfig
+                .builder().labels(Arrays.asList("0")).build());
         testConfigSerDe(ClassificationMetricsConfig
                 .builder().classificationLabels(Arrays.asList("0")).build());
         testConfigSerDe(RegressionMetricsConfig

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/metrics/ClassificationMetricsTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/metrics/ClassificationMetricsTests.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  * ******************************************************************************
+ *  *
+ *  *  * Copyright (c) 2019 Konduit AI.
+ *  *  *
+ *  *  * This program and the accompanying materials are made available under the
+ *  *  * terms of the Apache License, Version 2.0 which is available at
+ *  *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  *  * License for the specific language governing permissions and limitations
+ *  *  * under the License.
+ *  *  *
+ *  *  * SPDX-License-Identifier: Apache-2.0
+ *  *  *****************************************************************************
+ *
+ *
+ */
+package ai.konduit.serving.metrics;
+
+import ai.konduit.serving.config.metrics.impl.ClassificationMetricsConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.micrometer.backends.BackendRegistries;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClassificationMetricsTests {
+
+    @Test
+    public void testClassificationMetricsReset() {
+        ClassificationMetricsConfig classificationMetricsConfig = ClassificationMetricsConfig.builder()
+                .classificationLabels(Arrays.asList("0"))
+                .build();
+
+        ClassificationMetrics classificationMetrics = new ClassificationMetrics(classificationMetricsConfig);
+        classificationMetrics.bindTo(new SimpleMeterRegistry());
+        INDArray arr = Nd4j.scalar(1.0).reshape(1,1);
+        classificationMetrics.updateMetrics(new INDArray[] {arr});
+        double value = classificationMetrics.getClassCounterIncrement().get(0).value();
+        assertEquals(1.0,value,1e-3);
+        assertEquals(0.0,classificationMetrics.getClassCounterIncrement().get(0).value(),1e-3);
+    }
+
+}

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/metrics/MultiLabelClassificationMetricsTests.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/metrics/MultiLabelClassificationMetricsTests.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  * ******************************************************************************
+ *  *
+ *  *  * Copyright (c) 2019 Konduit AI.
+ *  *  *
+ *  *  * This program and the accompanying materials are made available under the
+ *  *  * terms of the Apache License, Version 2.0 which is available at
+ *  *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  *  * License for the specific language governing permissions and limitations
+ *  *  * under the License.
+ *  *  *
+ *  *  * SPDX-License-Identifier: Apache-2.0
+ *  *  *****************************************************************************
+ *
+ *
+ */
+package ai.konduit.serving.metrics;
+
+import ai.konduit.serving.config.metrics.impl.ClassificationMetricsConfig;
+import ai.konduit.serving.config.metrics.impl.MultiLabelMetricsConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class MultiLabelClassificationMetricsTests {
+
+    @Test
+    public void testClassificationMetricsReset() {
+        MultiLabelMetricsConfig classificationMetricsConfig = MultiLabelMetricsConfig.builder()
+                .labels(Arrays.asList("0"))
+                .build();
+
+        MultiLabelMetrics classificationMetrics = new MultiLabelMetrics(classificationMetricsConfig);
+        classificationMetrics.bindTo(new SimpleMeterRegistry());
+        INDArray arr = Nd4j.scalar(1.0).reshape(1,1);
+        classificationMetrics.updateMetrics(new INDArray[] {arr});
+        double value = classificationMetrics.getClassCounterIncrement().get(0).value();
+        assertEquals(1.0,value,1e-3);
+        assertEquals(0.0,classificationMetrics.getClassCounterIncrement().get(0).value(),1e-3);
+    }
+
+}

--- a/konduit-serving-test/src/test/java/ai/konduit/serving/metrics/RegressionMetricsTest.java
+++ b/konduit-serving-test/src/test/java/ai/konduit/serving/metrics/RegressionMetricsTest.java
@@ -1,0 +1,37 @@
+package ai.konduit.serving.metrics;
+
+import ai.konduit.serving.config.metrics.ColumnDistribution;
+import ai.konduit.serving.config.metrics.impl.RegressionMetricsConfig;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.preprocessor.serializer.NormalizerType;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class RegressionMetricsTest {
+
+    @Test
+    public void testRegressionValue() {
+        RegressionMetricsConfig regressionMetricsConfig = RegressionMetricsConfig.builder()
+                .regressionColumnLabels(Arrays.asList("test"))
+                .sampleTypes(Arrays.asList(RegressionMetricsConfig.SampleType.MEAN))
+                .columnDistributions(Arrays.asList(ColumnDistribution.builder()
+                .max(1.0).min(0.0).normalizerType(NormalizerType.MIN_MAX).build()))
+                .build();
+
+        RegressionMetrics regressionMetrics = new RegressionMetrics(regressionMetricsConfig);
+        regressionMetrics.bindTo(new SimpleMeterRegistry());
+
+        regressionMetrics.updateMetrics(new INDArray[] {Nd4j.scalar(1.0).reshape(1,1)});
+
+        Gauge gauge = regressionMetrics.getOutputStatsGauges().get(0);
+        double value = gauge.value();
+        assertEquals(1.0,value,1e-1);
+    }
+
+}


### PR DESCRIPTION
Classification counts are inflated unless they are reset upon export.  Metrics for classification are now reset, and it changes the metrics export to use a gauge rather than a counter so value scan go up and down.