### PR TITLE
Remove forkCount config to fix issues with Jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <junit.version>4.12</junit.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-        <dependency-check-maven.version>5.3.1</dependency-check-maven.version>
+        <dependency-check-maven.version>5.3.2</dependency-check-maven.version>
         <modelmapper.version>2.1.1</modelmapper.version>
         <jcommander.version>1.78</jcommander.version>
         <common.dbutils.version>1.6</common.dbutils.version>
@@ -661,9 +661,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>0</forkCount>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
@@ -1054,12 +1051,10 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <formats>
-                                <format>XML</format>
-                                <format>HTML</format>
-                            </formats>
+                            <format>XML</format>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                             <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
+                            <skipProvidedScope>true</skipProvidedScope>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Remove forkCount because of Jacoco fails with such config option
Update configuration for dependency-check-maven plugin