### PR TITLE
Implement (initial/basic) Data JSON ser/de; Data.equals

### DIFF
--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Data.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Data.java
@@ -18,19 +18,34 @@
 package ai.konduit.serving.pipeline.api.data;
 
 import ai.konduit.serving.pipeline.impl.data.*;
+import ai.konduit.serving.pipeline.impl.serde.DataJsonDeserializer;
+import ai.konduit.serving.pipeline.impl.serde.DataJsonSerializer;
+import ai.konduit.serving.pipeline.util.ObjectMappers;
 import lombok.NonNull;
+import org.nd4j.shade.jackson.core.JsonProcessingException;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+@JsonSerialize(using = DataJsonSerializer.class)
+@JsonDeserialize(using = DataJsonDeserializer.class)
 public interface Data {
 
     int size();
 
-    String toJson();
+    default String toJson(){
+        try {
+            return ObjectMappers.json().writeValueAsString(this);
+        } catch (JsonProcessingException e){
+            throw new RuntimeException("Error serializing Data instance to JSON", e);
+        }
+    }
 
     List<String> keys();
 
@@ -77,13 +92,21 @@ public interface Data {
     void setMetaData(Data data);
 
     // Serialization routines
-    void save(File toFile);
+    default void save(File toFile){
+        throw new UnsupportedOperationException();
+    }
 
 
-    void write(OutputStream toStream);
+    default void write(OutputStream toStream){
+        throw new UnsupportedOperationException();
+    }
 
-    static Data fromJson(String key) {
-        return null;
+    static Data fromJson(String json) {
+        try {
+            return ObjectMappers.json().readValue(json, Data.class);
+        } catch (JsonProcessingException e){
+            throw new RuntimeException("Error deserializing Data from JSON", e);
+        }
     }
 
     /*static Data fromFile(File file) {
@@ -98,6 +121,10 @@ public interface Data {
         return null;
     }
 
+    static Data fromFile(File f){
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
 
     static Data singleton(@NonNull String key, @NonNull Object value){
         return JData.singleton(key, value);
@@ -105,5 +132,72 @@ public interface Data {
 
     static Data empty(){
         return new JData();
+    }
+
+    static boolean equals(@NonNull Data d1, @NonNull Data d2){
+
+        if(d1.size() != d2.size())
+            return false;
+
+        List<String> k1 = d1.keys();
+        List<String> k2 = d2.keys();
+        if(!k1.containsAll(k2))
+            return false;
+
+        for(String s : k1){
+            if(d1.type(s) != d2.type(s))
+                return false;
+        }
+
+        //All keys and types are the same at this point
+        //Therefore check values
+        for(String s : k1){
+            ValueType vt = d1.type(s);
+            switch (vt){
+                case NDARRAY:
+                case LIST:
+                case IMAGE:
+                default:
+                    //TODO
+                    throw new UnsupportedOperationException(vt + " equality not yet implemented");
+                case STRING:
+                    if(!d1.getString(s).equals(d2.getString(s)))
+                        return false;
+                    break;
+                case BYTES:
+                    byte[] b1 = d1.getBytes(s);
+                    byte[] b2 = d2.getBytes(s);
+                    if(!Arrays.equals(b1, b2))
+                        return false;
+                    break;
+                case DOUBLE:
+                    double dbl1 = d1.getDouble(s);
+                    double dbl2 = d2.getDouble(s);
+                    if(dbl1 != dbl2 && !(Double.isNaN(dbl1) && Double.isNaN(dbl2))){        //Both equal, or both NaN
+                        return false;
+                    }
+                    break;
+                case INT64:
+                    long l1 = d1.getLong(s);
+                    long l2 = d2.getLong(s);
+                    if(l1 != l2)
+                        return false;
+                    break;
+                case BOOLEAN:
+                    boolean bool1 = d1.getBoolean(s);
+                    boolean bool2 = d2.getBoolean(s);
+                    if(bool1 != bool2)
+                        return false;
+                    break;
+                case DATA:
+                    Data d1a = d1.getData(s);
+                    Data d2a = d2.getData(s);
+                    if(!equals(d1a, d2a))
+                        return false;
+
+            }
+        }
+
+        return true;
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/JData.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/JData.java
@@ -23,7 +23,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.io.*;
 import java.util.*;
 
 @Slf4j
@@ -39,11 +38,6 @@ public class JData implements Data {
     @Override
     public int size() {
         return dataMap.size();
-    }
-
-    @Override
-    public String toJson() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -147,8 +141,8 @@ public class JData implements Data {
 
     @Override
     public Data getData(String key) {
-        Data data = (Data)dataMap.get(key);
-        return data;
+        Value<Data> data = valueIfFound(key, ValueType.DATA);
+        return data.get();
     }
 
     @Override
@@ -158,7 +152,7 @@ public class JData implements Data {
 
     @Override
     public void put(String key, NDArray data) {
-        dataMap.put(key, new INDArrayValue(data));
+        dataMap.put(key, new NDArrayValue(data));
     }
 
     @Override
@@ -188,8 +182,7 @@ public class JData implements Data {
 
     @Override
     public void put(String key, Data data) {
-        // TODO: must avoid cast and redesign method
-        this.dataMap.putAll(((JData)data).getDataMap());
+        this.dataMap.put(key, new DataValue(data));
     }
 
     @Override
@@ -208,23 +201,12 @@ public class JData implements Data {
     }
 
     @Override
-    public void save(File toFile) {
-
-        throw new UnsupportedOperationException();
+    public boolean equals(Object o){
+        if(!(o instanceof Data))
+            return false;
+        return Data.equals(this, (Data)o);
     }
 
-    public static Data fromFile(File fromFile) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void write(OutputStream toStream) {
-        throw new UnsupportedOperationException();
-    }
-
-    public byte[] asBytes() {
-        throw new UnsupportedOperationException();
-    }
 
     public static Data empty() {
         Data retVal = new JData();

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BaseValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BaseValue.java
@@ -1,0 +1,46 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.pipeline.impl.data.wrappers;
+
+import ai.konduit.serving.pipeline.impl.data.Value;
+import ai.konduit.serving.pipeline.impl.data.ValueType;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class BaseValue<T> implements Value<T> {
+
+    protected final ValueType type;
+    protected T value;
+
+
+    @Override
+    public ValueType type() {
+        return type;
+    }
+
+    @Override
+    public T get() {
+        return value;
+    }
+
+    @Override
+    public void set(T value) {
+        this.value = value;
+    }
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BooleanValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BooleanValue.java
@@ -15,27 +15,10 @@
  ******************************************************************************/
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
-import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class BooleanValue implements Value<Boolean> {
-
-    private boolean value;
-
-    @Override
-    public ValueType type() {
-        return ValueType.BOOLEAN;
-    }
-
-    @Override
-    public Boolean get() {
-        return value;
-    }
-
-    @Override
-    public void set(Boolean value) {
-        this.value = value;
+public class BooleanValue extends BaseValue<Boolean> {
+    public BooleanValue(Boolean value) {
+        super(ValueType.BOOLEAN, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BytesValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BytesValue.java
@@ -15,27 +15,10 @@
  ******************************************************************************/
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
-import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class BytesValue implements Value<byte[]> {
-
-    private byte[] value;
-
-    @Override
-    public byte[] get() {
-        return this.value;
-    }
-
-    @Override
-    public void set(byte[] values) {
-        this.value = values;
-    }
-
-    @Override
-    public ValueType type() {
-        return ValueType.BYTES;
+public class BytesValue extends BaseValue<byte[]> {
+    public BytesValue(byte[] value) {
+        super(ValueType.BYTES, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/DataValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/DataValue.java
@@ -1,0 +1,28 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.pipeline.impl.data.wrappers;
+
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.impl.data.ValueType;
+
+public class DataValue extends BaseValue<Data> {
+    public DataValue(Data value) {
+        super(ValueType.DATA, value);
+    }
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/DoubleValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/DoubleValue.java
@@ -15,27 +15,11 @@
  ******************************************************************************/
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
-import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class DoubleValue implements Value<Double> {
+public class DoubleValue extends BaseValue<Double> {
 
-    private double value;
-
-    @Override
-    public ValueType type() {
-        return ValueType.DOUBLE;
-    }
-
-    @Override
-    public Double get() {
-        return value;
-    }
-
-    @Override
-    public void set(Double value) {
-        this.value = value;
+    public DoubleValue(Double value) {
+        super(ValueType.DOUBLE, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/ImageValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/ImageValue.java
@@ -16,26 +16,11 @@
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
 import ai.konduit.serving.pipeline.api.data.Image;
-import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class ImageValue implements Value<Image> {
-    private Image image;
+public class ImageValue extends BaseValue<Image> {
 
-    @Override
-    public ValueType type() {
-        return ValueType.IMAGE;
-    }
-
-    @Override
-    public Image get() {
-        return image;
-    }
-
-    @Override
-    public void set(Image value) {
-        this.image = value;
+    public ImageValue(Image value) {
+        super(ValueType.IMAGE, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/IntValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/IntValue.java
@@ -15,26 +15,11 @@
  ******************************************************************************/
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
-import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class IntValue implements Value<Long> {
-    private long value;
+public class IntValue extends BaseValue<Long> {
 
-    @Override
-    public ValueType type() {
-        return ValueType.INT64;
-    }
-
-    @Override
-    public Long get() {
-        return value;
-    }
-
-    @Override
-    public void set(Long value) {
-        this.value = value;
+    public IntValue(Long value) {
+        super(ValueType.INT64, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/NDArrayValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/NDArrayValue.java
@@ -15,26 +15,13 @@
  ******************************************************************************/
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
+import ai.konduit.serving.pipeline.api.data.NDArray;
 import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class INDArrayValue implements Value<Object> {
-    private Object value;
-
-    @Override
-    public Object get() {
-        return value;
-    }
-
-    @Override
-    public void set(Object value) {
-        this.value = value;
-    }
-
-    @Override
-    public ValueType type() {
-        return ValueType.NDARRAY;
+public class NDArrayValue extends BaseValue<NDArray> {
+    public NDArrayValue(NDArray value) {
+        super(ValueType.NDARRAY, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/StringValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/StringValue.java
@@ -15,30 +15,10 @@
  ******************************************************************************/
 package ai.konduit.serving.pipeline.impl.data.wrappers;
 
-import ai.konduit.serving.pipeline.impl.data.Value;
 import ai.konduit.serving.pipeline.impl.data.ValueType;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class StringValue implements Value<String> {
-    private String value;
-
-    public void setValue(Object input) {
-        value = (String)input;
-    }
-
-    @Override
-    public String get() {
-        return value;
-    }
-
-    @Override
-    public void set(String value) {
-        this.value = value;
-    }
-
-    @Override
-    public ValueType type() {
-        return ValueType.STRING;
+public class StringValue extends BaseValue<String> {
+    public StringValue(String value) {
+        super(ValueType.STRING, value);
     }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/serde/DataJsonDeserializer.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/serde/DataJsonDeserializer.java
@@ -1,0 +1,86 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.pipeline.impl.serde;
+
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.impl.data.JData;
+import org.nd4j.shade.jackson.core.JsonParser;
+import org.nd4j.shade.jackson.core.JsonProcessingException;
+import org.nd4j.shade.jackson.databind.DeserializationContext;
+import org.nd4j.shade.jackson.databind.JsonDeserializer;
+import org.nd4j.shade.jackson.databind.JsonNode;
+import org.nd4j.shade.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Iterator;
+
+public class DataJsonDeserializer extends JsonDeserializer<Data> {
+    @Override
+    public Data deserialize(JsonParser jp, DeserializationContext dc) throws IOException, JsonProcessingException {
+        JsonNode n = jp.getCodec().readTree(jp);
+        return deserialize(jp, n);
+    }
+
+    public Data deserialize(JsonParser jp, JsonNode n){
+        JData d = new JData();
+
+        Iterator<String> names = n.fieldNames();
+        while(names.hasNext()){
+            String s = names.next();
+            JsonNode n2 = n.get(s);
+            if(n2.isTextual()){                     //String
+                String str = n2.textValue();
+                d.put(s, str);
+            } else if(n2.isDouble()){               //Double
+                double dVal = n2.doubleValue();
+                d.put(s, dVal);
+            } else if(n2.isInt() || n2.isLong()){   //Long
+                long lVal = n2.longValue();
+                d.put(s, lVal);
+            } else if(n2.isBoolean()) {              //Boolean
+                boolean b = n2.booleanValue();
+                d.put(s, b);
+            } else if(n2.isObject() && n2.has("format")) {
+                String format = n2.get("format").textValue();
+                if ("BASE64".equalsIgnoreCase(format)) {
+                    String str = n2.get("bytes").textValue();
+                    byte[] bytes = Base64.getDecoder().decode(str);
+                    d.put(s, bytes);
+                } else {
+                    ArrayNode n3 = (ArrayNode) n2.get("bytes");
+                    int size = n3.size();
+                    byte[] b = new byte[size];
+                    for (int i = 0; i < size; i++) {
+                        b[i] = (byte) n3.get(i).asInt();        //TODO range checks?
+                    }
+                    d.put(s, b);
+                }
+            } else if(n2.isObject()){
+                ///TODO - potential bug - nested Data instance when Data has key "format" - ambiguous with byte[] encoding
+                Data dInner = deserialize(jp, n2);
+                d.put(s, dInner);
+            } else {
+                throw new UnsupportedOperationException("Type not yet implemented");
+            }
+        }
+
+        return d;
+    }
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/serde/DataJsonSerializer.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/serde/DataJsonSerializer.java
@@ -1,0 +1,152 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.pipeline.impl.serde;
+
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.impl.data.ValueType;
+import ai.konduit.serving.pipeline.util.ObjectMappers;
+import org.nd4j.shade.jackson.core.JsonGenerator;
+import org.nd4j.shade.jackson.core.JsonProcessingException;
+import org.nd4j.shade.jackson.databind.JsonSerializer;
+import org.nd4j.shade.jackson.databind.ObjectMapper;
+import org.nd4j.shade.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+public class DataJsonSerializer extends JsonSerializer<Data> {
+    @Override
+    public void serialize(Data data, JsonGenerator jg, SerializerProvider sp) throws IOException {
+        //TODO do we serialize in any particular order?
+
+        jg.writeStartObject();
+
+        List<String> l = data.keys();
+
+        for(String s : l){
+            ValueType vt = data.type(s);
+
+            switch (vt){
+                case NDARRAY:
+                    break;
+                case STRING:
+                    String str = data.getString(s);
+                    jg.writeFieldName(s);
+                    jg.writeString(str);
+                    break;
+                case BYTES:
+                    byte[] bytes = data.getBytes(s);
+                    //For bytes: write as follows
+                    /*
+                    "myBytes" : {
+                        "bytesFormat": "ARRAY" (or "BASE64")
+                        bytes = ... ([1,2,3] or "<some base64 string>"
+                    }
+                     */
+
+                    //TODO add option to do raw bytes array - [0, 1, 2, ...] style
+
+                    jg.writeFieldName(s);
+                    jg.writeStartObject();
+                    jg.writeFieldName("format");
+                    jg.writeString("BASE64");
+                    String base64 = Base64.getEncoder().encodeToString(bytes);
+                    jg.writeFieldName("bytes");
+                    jg.writeString(base64);
+                    jg.writeEndObject();
+                    break;
+                case IMAGE:
+                    break;
+                case DOUBLE:
+                    writeDouble(jg, s, data.getDouble(s));
+                    break;
+                case INT64:
+                    writeLong(jg, s, data.getLong(s));
+                    break;
+                case BOOLEAN:
+                    boolean b = data.getBoolean(s);
+                    jg.writeFieldName(s);
+                    jg.writeBoolean(b);
+                    break;
+                case DATA:
+                    //TODO Fix formatting: it doesn't correctly indent...
+                    Data d = data.getData(s);
+                    jg.writeFieldName(s);
+                    ObjectMapper om = (ObjectMapper) jg.getCodec();
+                    String dataStr = om.writeValueAsString(d);
+                    jg.writeRawValue(dataStr);
+                    break;
+                case LIST:
+                    jg.writeFieldName(s);
+                    ValueType listVt = data.listType(s);
+                    List<?> list = data.getList(s, listVt);
+                    writeList(jg, list, listVt);
+                    break;
+            }
+        }
+
+        jg.writeEndObject();
+    }
+
+    private void writeDouble(JsonGenerator jg, String s, double d) throws IOException {
+        jg.writeFieldName(s);
+        jg.writeNumber(d);
+    }
+
+    private void writeLong(JsonGenerator jg, String s, long l) throws IOException {
+        jg.writeFieldName(s);
+        jg.writeNumber(l);
+    }
+
+    private void writeList(JsonGenerator jg, List<?> list, ValueType listType) throws IOException {
+        int n = list.size();
+        jg.writeStartArray(n);
+
+        int i=0;
+        switch (listType){
+            case NDARRAY:
+                break;
+            case STRING:
+                break;
+            case BYTES:
+                break;
+            case IMAGE:
+                break;
+            case DOUBLE:
+                List<Double> dList = (List<Double>)list;        //TODO checks for unsafe cast?
+                double[] dArr = new double[dList.size()];
+                for(Double d : dList){
+                    dArr[i++] = d;
+                }
+                jg.writeArray(dArr, 0, dArr.length);
+                break;
+            case INT64:
+                break;
+            case BOOLEAN:
+                break;
+            case DATA:
+                break;
+            case LIST:
+                break;
+        }
+
+        jg.writeEndArray();
+    }
+}

--- a/konduit-serving-pipeline/src/test/java/ai/konduit/serving/pipeline/impl/data/DataJsonTest.java
+++ b/konduit-serving-pipeline/src/test/java/ai/konduit/serving/pipeline/impl/data/DataJsonTest.java
@@ -1,0 +1,134 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.pipeline.impl.data;
+
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.NDArray;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataJsonTest {
+
+    @Test
+    public void testBasic(){
+
+        for(ValueType vt : ValueType.values()){
+            if(vt == ValueType.IMAGE || vt == ValueType.LIST || vt == ValueType.NDARRAY){
+                System.out.println("SKIPPING: " + vt);
+                continue;
+            }
+
+            System.out.println(" ----- " + vt + " -----");
+
+            Data d;
+            switch (vt){
+                case NDARRAY:
+                    d = Data.singleton("myKey", NDArray.create(new float[]{0,1,2}));
+                    break;
+                case STRING:
+                    d = Data.singleton("myKey", "myString");
+                    break;
+                case BYTES:
+                    d = Data.singleton("myKey", new byte[]{0,1,2});
+                    break;
+                case IMAGE:
+                    d = null;
+                    break;
+                case DOUBLE:
+                    d = Data.singleton("myKey", 1.0);
+                    break;
+                case INT64:
+                    d = Data.singleton("myKey", 1L);
+                    break;
+                case BOOLEAN:
+                    d = Data.singleton("myKey", true);
+                    break;
+                case DATA:
+                    d = Data.singleton("myKey", Data.singleton("myInnerKey", "myInnerValue"));
+                    break;
+                case LIST:
+                    d = null;
+                    break;
+                default:
+                    d = null;
+            }
+
+            String s = d.toJson();
+
+            Data d2 = Data.fromJson(s);
+            assertEquals(d, d2);
+
+            System.out.println(s);
+        }
+    }
+
+    @Test
+    public void testNestedData(){
+
+        Data dInner = Data.singleton("inner", 1.0);
+        Data dOuter = Data.singleton("outer", dInner);
+
+        String json = dOuter.toJson();
+        System.out.println(json);
+
+        Data dOuterJson = Data.fromJson(json);
+
+        assertEquals(dOuter, dOuterJson);
+
+        Data dInnerJson = dOuterJson.getData("outer");
+        assertEquals(dInner, dInnerJson);
+    }
+
+    @Ignore     //NO WAY TO PUT LISTS INTO DATA YET
+    @Test
+    public void testList(){
+
+        for(ValueType vt : ValueType.values()) {
+            if (vt == ValueType.IMAGE || vt == ValueType.DATA || vt == ValueType.LIST || vt == ValueType.NDARRAY) {
+                System.out.println("SKIPPING: " + vt);
+                continue;
+            }
+
+            Data d;
+            switch (vt){
+                case STRING:
+                    List<String> strList = Arrays.asList("test", "string", "list");
+
+                    break;
+                case BYTES:
+                    break;
+                case DOUBLE:
+                    break;
+                case INT64:
+                    break;
+                case BOOLEAN:
+                    break;
+            }
+
+
+        }
+
+    }
+
+}

--- a/konduit-serving-pipeline/src/test/java/ai/konduit/serving/pipeline/impl/data/DataTest.java
+++ b/konduit-serving-pipeline/src/test/java/ai/konduit/serving/pipeline/impl/data/DataTest.java
@@ -117,7 +117,7 @@ public class DataTest {
     public void testSerde() {
         Data someData = JData.singleton(KEY, Long.valueOf(200));
         someData.save(new File("temp"));
-        Data restoredData = JData.fromFile(new File("temp"));
+        Data restoredData = Data.fromFile(new File("temp"));
     }
 
     @Test


### PR DESCRIPTION
JSON serialization and deserialization implemented for Data instances for types:
STRING, BYTES, DOUBLE, INT64, BOOLEAN, DATA.

Not yet implemented for:
NDARRAY, IMAGE, LIST

Note that all Data instances (JData, soon ProtoData) will have identical JSON representation.

Some notes:
* Currently bytes[] and nested Data instances can be ambiguous - need to fix this
* Formatting for nested Data instances isn't ideal (JSON is correct, but missing indentation)