### PR TITLE
Add bounding box datatype

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -15,7 +15,8 @@ See `ADRs/0003-Pipeline-API_Rewrite.md` for background and motivation on the cur
 * PipelineStepRunner: An interface for running a PipelineStep
 * PipelineStepRunnerFactory: For creating PipelineStepRunner from PipelineExecutor. Explained in more detail later.
 * Data: A map-like store of key-value pairs.
-    * Keys are always Strings, values are one of: {String, int64 (long), double, boolean, NDArray, byte[], Image, List[T], Data} where T is any of these types.
+    * Keys are always Strings, values are one of: {String, int64 (long), double, boolean, NDArray, byte[], Image, bounding box,
+     List[T], Data} where T is any of these types.
       Note that we allow nested Data and List objects.
     * Data instances also have optional metadata, stored as a nested Data instance 
     * Note NDArray and Image are special cases here, discussed in detail below
@@ -134,6 +135,7 @@ Again, the supported datatypes include: (see `ValueType` enum):
 * BOOLEAN
 * DATA
 * LIST
+* BOUNDING_BOX
 
 `JData` is the Java Map-based implementation of the `Data` interface - i.e., literally it has a `Map<String,Value<T>>` internally,
 where `Value<T>` is a trivially simple object to hold objects of different types.
@@ -254,7 +256,6 @@ As of 07/05/2020 supported formats for images include:
 * BufferedImage
 * JavaCV Mat    (konduit-serving-javacv)
 * JavaCV Frame  (konduit-serving-javacv)
-* OpenCV Mat    (konduit-serving-javacv)
 More formats will be added in the future.
 
 As of 07/05/2020 supported NDArray formats include:
@@ -368,17 +369,37 @@ As for the actual JSON format - this is basically as follows (taken from DataJso
 {
   "myKey" : true
 }
+ ----- BOUNDING_BOX -----
+{
+  "myKey" : {
+    "@cx" : 0.5,
+    "@cy" : 0.4,
+    "@h" : 0.9,
+    "@w" : 1.0
+  },
+  "myKey2" : {
+    "@x1" : 0.1,
+    "@x2" : 1.0,
+    "@y1" : 0.2,
+    "@y2" : 0.9,
+    "label" : "label",
+    "probability" : 0.7
+  }
+}
  ----- DATA -----
 {
   "myKey" : {
-    "myInnerKey" : "myInnerValue"
-  }
+  "myInnerKey" : "myInnerValue"
+}
+}
+ ----- LIST -----
+{
+  "myKey" : [ "some", "list", "values" ]
 }
 ```
 
-Note that strings, bytes, double, int64 and boolean are basically as you would expect.  
-The format for nested Data instances is identical to the non-nested ones.  
-List formats (not shown above) will use JSON arrays - so it'll look like `"myKey" : ["some", "list", "values"]`  
+Note that strings, bytes, double, int64, boolean and lists are basically as you would expect.  
+The format for nested Data instances is identical to the non-nested ones.    
 Bytes, is a special case - it's an object with a special protected key: `@BytesBase64`. Currently (and by default) we
 will encode `byte[]` objects as base64 format for space efficiency; later we will allow "array style" byte[] encoding
 (i.e., `"@BytesArray" : [1,2,3]`). Users are not allowed to add anything to a Data instance with these protected keys.
@@ -387,6 +408,9 @@ Image data is stored by default in PNG format, base64 encoded (this will be conf
 
 NDArray is a special case also: it in a JSON object with type/shape/data keys. Currently data is base64 encoded, but
 we may allow a "1d buffer array" format in the future also.
+
+Bounding boxes are also stored with special keys in either (cx, cy, h, w) format or (x1, x2, y1, y2) format, again with
+special/reserved names to differentiate a bounding box from a Data instance (otherwise the JSON would be ambiguous). 
 
 The full set of protected keys can be found on the Data interface. They include:
 * @BytesBase64
@@ -397,6 +421,8 @@ The full set of protected keys can be found on the Data interface. They include:
 * @NDArrayType
 * @NDArrayDataBase64
 * @Metadata
+* Bounding box: @x1, @x2, @y1, @y2
+* Bounding box: @cx, @cy, @h, @w 
 
 In practice, Data JSON serialization/deserialization is implemneted in the DataJsonSerializer and DataJsonDeserializer classes. 
 
@@ -457,10 +483,4 @@ It's fine to have sub-packages (i.e., any X in `ai.konduit.serving.data.nd4j.X` 
 in the same package - i.e., modules X and Y can't both define classes directly in the same namespace.
 The reason is to avoid split packages issues for OSGi and Java 9 Modules. We will likely use OSGi extensively in the future.
 
- 
-
-
-
-
- 
  

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/BoundingBox.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/BoundingBox.java
@@ -1,0 +1,57 @@
+package ai.konduit.serving.pipeline.api.data;
+
+import ai.konduit.serving.pipeline.impl.data.box.BBoxCHW;
+import ai.konduit.serving.pipeline.impl.data.box.BBoxXY;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Objects;
+
+public interface BoundingBox {
+
+    static BoundingBox create(double cx, double cy, double h, double w){
+        return create(cx, cy, h, w, null, null);
+    }
+
+    static BoundingBox create(double cx, double cy, double h, double w, String label, Double probability){
+        return new BBoxCHW(cx, cy, h, w, label, probability);
+    }
+
+    static BoundingBox createXY(double x1, double x2, double y1, double y2){
+        return createXY(x1, x2, y1, y2, null, null);
+    }
+
+    static BoundingBox createXY(double x1, double x2, double y1, double y2, String label, Double probability){
+        return new BBoxXY(x1, x2, y1, y2, label, probability);
+    }
+
+    double x1();
+
+    double x2();
+
+    double y1();
+
+    double y2();
+
+    double cx();
+
+    double cy();
+
+    String label();
+
+    Double probability();
+
+    static boolean equals(BoundingBox bb1, BoundingBox bb2) {
+        return equals(bb1, bb2, 1e-5);
+    }
+
+    static boolean equals(BoundingBox bb1, BoundingBox bb2, double eps){
+        return Math.abs(bb1.x1() - bb2.x1()) < eps &&
+                Math.abs(bb1.x2() - bb2.x2()) < eps &&
+                Math.abs(bb1.y1() - bb2.y1()) < eps &&
+                Math.abs(bb1.y2() - bb2.y2()) < eps &&
+                Objects.equals(bb1.label(), bb2.label()) &&
+                ((bb1.probability() == null && bb2.probability() == null) ||
+                        (bb1.probability() != null && Math.abs(bb1.probability() - bb2.probability()) < eps) );
+    }
+
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/BoundingBox.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/BoundingBox.java
@@ -2,56 +2,133 @@ package ai.konduit.serving.pipeline.api.data;
 
 import ai.konduit.serving.pipeline.impl.data.box.BBoxCHW;
 import ai.konduit.serving.pipeline.impl.data.box.BBoxXY;
-import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Objects;
 
+/**
+ * BoundingBox is usually used to represent a rectangular region in an image, along with an optional String label,
+ * and an aptional double probability.
+ * <p>
+ * Bounding boxes can be defined in two (essentially equivalent) formats:<br>
+ * (a) Based on center X, center Y, height and width<br>
+ * (b) Based on x1, x2, y1 and y2 locations (i.e., lower/upper X, lower/upper Y coordinate)<br>
+ * <p>
+ * As a general rule, bounding box coordinates are specified as a fraction of the image - with coordinates (x,y)=(0.0, 0.0)
+ * being top left of the image, and (x,y)=(1.0, 1.0) being the bottom right of the image.<br>
+ * However, in some use cases, specifying x/y locations in pixels might be used.
+ *
+ * @author Alex Black
+ */
 public interface BoundingBox {
 
-    static BoundingBox create(double cx, double cy, double h, double w){
+    /**
+     * As per {@link #createXY(double, double, double, double, String, Double)} without a label or probability
+     */
+    static BoundingBox create(double cx, double cy, double h, double w) {
         return create(cx, cy, h, w, null, null);
     }
 
-    static BoundingBox create(double cx, double cy, double h, double w, String label, Double probability){
+    /**
+     * Create a BoundingBox instance based on the center X/Y location and box height/width.
+     * As per {@link BoundingBox}, specifying these as as a fraction of image size (i.e., 0.0 to 1.0) is generally preferred
+     *
+     * @param cx          Center X location
+     * @param cy          Center Y location
+     * @param h           Height
+     * @param w           Width
+     * @param label       Label for the bounding box. May be null.
+     * @param probability PRobability for the bounding box, in range [0.0, 1.0]. May be null
+     * @return BoundingBox instance
+     */
+    static BoundingBox create(double cx, double cy, double h, double w, String label, Double probability) {
         return new BBoxCHW(cx, cy, h, w, label, probability);
     }
 
-    static BoundingBox createXY(double x1, double x2, double y1, double y2){
+
+    static BoundingBox createXY(double x1, double x2, double y1, double y2) {
         return createXY(x1, x2, y1, y2, null, null);
     }
 
-    static BoundingBox createXY(double x1, double x2, double y1, double y2, String label, Double probability){
+    /**
+     * Create a BoundingBox instance based on lower/upper X/Y coordinates of the box.<br>
+     * i.e., the top-left of the box is defined by (x1, y1) and the bottom-right is defined by (x2, y2)<br>
+     * As per {@link BoundingBox}, specifying these as as a fraction of image size (i.e., 0.0 to 1.0) is generally preferred
+     *
+     * @param x1          The lower X coordinate for the box (i.e., top-left X coordinate)
+     * @param x2          The upper X coordinate for the box (i.e., bottom-right X coordinate)
+     * @param y1          The smaller Y coordinate for the box (i.e., top-left Y coordinate)
+     * @param y2          The larger Y coordinate for the box (i.e., bottom-right Y coordinate)
+     * @param label       Label for the bounding box. May be null.
+     * @param probability PRobability for the bounding box, in range [0.0, 1.0]. May be null
+     * @return BoundingBox instance
+     */
+    static BoundingBox createXY(double x1, double x2, double y1, double y2, String label, Double probability) {
         return new BBoxXY(x1, x2, y1, y2, label, probability);
     }
 
+    /**
+     * @return The lower X coordinate (i.e., top-left X coordinate)
+     */
     double x1();
 
+    /**
+     * @return The upper X coordinate (i.e., bottom-right X coordinate)
+     */
     double x2();
 
+    /**
+     * @return The smaller Y coordinate (i.e., top-left Y coordinate)
+     */
     double y1();
 
+    /**
+     * @return The larger X coordinate (i.e., bottom-right Y coordinate)
+     */
     double y2();
 
+    /**
+     * @return The bounding box center X coordinate
+     */
     double cx();
 
+    /**
+     * @return The bounding box center Y coordinate
+     */
     double cy();
 
+    /**
+     * @return The label for the bounding box. May be null.
+     */
     String label();
 
+    /**
+     * @return The probability for the bounding box. May be null.
+     */
     Double probability();
 
+    /**
+     * As per {@link #equals(BoundingBox, BoundingBox, double, double)} using eps = 1e-5 and probEps = 1e-5
+     */
     static boolean equals(BoundingBox bb1, BoundingBox bb2) {
-        return equals(bb1, bb2, 1e-5);
+        return equals(bb1, bb2, 1e-5, 1e-5);
     }
 
-    static boolean equals(BoundingBox bb1, BoundingBox bb2, double eps){
+    /**
+     * @param bb1     First bounding box to compare
+     * @param bb2     Second bounding box to compare
+     * @param eps     Epsilon value for X/Y coordinates. Use 0.0 for exact, or non-zero for "approximately equals" behaviour
+     * @param probEps Epsilon value for probability comparison. Use 0.0 for exact probability match, or non-zero for "approximately
+     *                equal" behavior. Unused if one/both bounding boxes don't have a probability value
+     * @return True if the two bounding boxes are equals, false otherwise
+     */
+    static boolean equals(BoundingBox bb1, BoundingBox bb2, double eps, double probEps) {
         return Math.abs(bb1.x1() - bb2.x1()) < eps &&
                 Math.abs(bb1.x2() - bb2.x2()) < eps &&
                 Math.abs(bb1.y1() - bb2.y1()) < eps &&
                 Math.abs(bb1.y2() - bb2.y2()) < eps &&
                 Objects.equals(bb1.label(), bb2.label()) &&
                 ((bb1.probability() == null && bb2.probability() == null) ||
-                        (bb1.probability() != null && Math.abs(bb1.probability() - bb2.probability()) < eps) );
+                        (bb1.probability() != null && Math.abs(bb1.probability() - bb2.probability()) < probEps));
     }
 
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Data.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Data.java
@@ -48,11 +48,22 @@ public interface Data {
     String RESERVED_KEY_NDARRAY_DATA_BASE64 = "@NDArrayDataBase64";
     String RESERVED_KEY_NDARRAY_DATA_ARRAY = "@NDArrayDataBase64";
     String RESERVED_KEY_METADATA = "@Metadata";
+    String RESERVED_KEY_BB_X1 = "@x1";
+    String RESERVED_KEY_BB_X2 = "@x2";
+    String RESERVED_KEY_BB_Y1 = "@y1";
+    String RESERVED_KEY_BB_Y2 = "@y2";
+    String RESERVED_KEY_BB_CX = "@cx";
+    String RESERVED_KEY_BB_CY = "@cy";
+    String RESERVED_KEY_BB_H = "@h";
+    String RESERVED_KEY_BB_W = "@w";
+
 
     static List<String> reservedKeywords(){
         return Arrays.asList(RESERVED_KEY_BYTES_BASE64, RESERVED_KEY_BYTES_ARRAY, RESERVED_KEY_IMAGE_FORMAT,
                 RESERVED_KEY_IMAGE_DATA, RESERVED_KEY_NDARRAY_SHAPE, RESERVED_KEY_NDARRAY_TYPE, RESERVED_KEY_NDARRAY_DATA_BASE64,
-                RESERVED_KEY_NDARRAY_DATA_ARRAY, RESERVED_KEY_METADATA);
+                RESERVED_KEY_NDARRAY_DATA_ARRAY, RESERVED_KEY_METADATA,
+                RESERVED_KEY_BB_X1, RESERVED_KEY_BB_X2, RESERVED_KEY_BB_Y1, RESERVED_KEY_BB_Y2,
+                RESERVED_KEY_BB_CX, RESERVED_KEY_BB_CY, RESERVED_KEY_BB_H, RESERVED_KEY_BB_W);
     }
 
     int size();
@@ -91,6 +102,7 @@ public interface Data {
     double getDouble(String key) throws ValueNotFoundException;
     Image getImage(String key) throws ValueNotFoundException;
     long getLong(String key) throws ValueNotFoundException;
+    BoundingBox getBoundingBox(String key) throws ValueNotFoundException;
     List<Object> getList(String key, ValueType type);                   //TODO type
     Data getData(String key);
 
@@ -101,6 +113,7 @@ public interface Data {
     void put(String key, long data);
     void put(String key, double data);
     void put(String key, boolean data);
+    void put(String key, BoundingBox data);
 
     void putListString(String key, List<String> data);
     void putListInt64(String key, List<Long> data);
@@ -110,6 +123,7 @@ public interface Data {
     void putListData(String key, List<Data> data);
     void putListImage(String key, List<Image> data);
     void putListNDArray(String key, List<NDArray> data);
+    void putListBoundingBox(String key, List<BoundingBox> data);
     void put(String key, Data data);
 
     boolean hasMetaData();
@@ -258,7 +272,13 @@ public interface Data {
                     Data d2a = d2.getData(s);
                     if(!equals(d1a, d2a))
                         return false;
-
+                    break;
+                case BOUNDING_BOX:
+                    BoundingBox bb1 = d1.getBoundingBox(s);
+                    BoundingBox bb2 = d2.getBoundingBox(s);
+                    if(!BoundingBox.equals(bb1, bb2))
+                        return false;
+                    break;
             }
         }
 

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/ValueType.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/ValueType.java
@@ -25,6 +25,7 @@ public enum ValueType {
     DOUBLE,
     INT64,
     BOOLEAN,
+    BOUNDING_BOX,
     DATA,
     LIST
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxCHW.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxCHW.java
@@ -1,3 +1,20 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
 package ai.konduit.serving.pipeline.impl.data.box;
 
 import ai.konduit.serving.pipeline.api.data.BoundingBox;

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxCHW.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxCHW.java
@@ -1,0 +1,58 @@
+package ai.konduit.serving.pipeline.impl.data.box;
+
+import ai.konduit.serving.pipeline.api.data.BoundingBox;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class BBoxCHW implements BoundingBox {
+
+    private final double cx;
+    private final double cy;
+    private final double h;
+    private final double w;
+    private final String label;
+    private final Double probability;
+
+    public BBoxCHW(double cx, double cy, double h, double w){
+        this(cx, cy, h, w, null, null);
+    }
+
+    public BBoxCHW(double cx, double cy, double h, double w, String label, Double probability){
+        this.cx = cx;
+        this.cy = cy;
+        this.h = h;
+        this.w = w;
+        this.label = label;
+        this.probability = probability;
+    }
+
+
+    @Override
+    public double x1() {
+        return cx - w/2;
+    }
+
+    @Override
+    public double x2() {
+        return cx + w/2;
+    }
+
+    @Override
+    public double y1() {
+        return cy - h/2;
+    }
+
+    @Override
+    public double y2() {
+        return cy + h/2;
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(!(o instanceof BoundingBox))
+            return false;
+        return BoundingBox.equals(this, (BoundingBox)o);
+    }
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxXY.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxXY.java
@@ -1,3 +1,20 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
 package ai.konduit.serving.pipeline.impl.data.box;
 
 import ai.konduit.serving.pipeline.api.data.BoundingBox;

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxXY.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/box/BBoxXY.java
@@ -1,0 +1,48 @@
+package ai.konduit.serving.pipeline.impl.data.box;
+
+import ai.konduit.serving.pipeline.api.data.BoundingBox;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class BBoxXY implements BoundingBox {
+
+    private final double x1;
+    private final double x2;
+    private final double y1;
+    private final double y2;
+    private final String label;
+    private final Double probability;
+
+    public BBoxXY(double x1, double x2, double y1, double y2){
+        this(x1, x2, y1, y2, null, null);
+    }
+
+    public BBoxXY(double x1, double x2, double y1, double y2, String label, Double probability){
+        this.x1 = x1;
+        this.x2 = x2;
+        this.y1 = y1;
+        this.y2 = y2;
+        this.label = label;
+        this.probability = probability;
+    }
+
+
+    @Override
+    public double cx() {
+        return (x1+x2)/2;
+    }
+
+    @Override
+    public double cy() {
+        return (y1+y2)/2;
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(!(o instanceof BoundingBox))
+            return false;
+        return BoundingBox.equals(this, (BoundingBox)o);
+    }
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BBoxValue.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/wrappers/BBoxValue.java
@@ -1,0 +1,25 @@
+/* ******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package ai.konduit.serving.pipeline.impl.data.wrappers;
+
+import ai.konduit.serving.pipeline.api.data.BoundingBox;
+import ai.konduit.serving.pipeline.api.data.ValueType;
+
+public class BBoxValue extends BaseValue<BoundingBox> {
+    public BBoxValue(BoundingBox value) {
+        super(ValueType.BOUNDING_BOX, value);
+    }
+}

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/serde/DataJsonSerializer.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/serde/DataJsonSerializer.java
@@ -18,11 +18,9 @@
 
 package ai.konduit.serving.pipeline.impl.serde;
 
-import ai.konduit.serving.pipeline.api.data.Data;
-import ai.konduit.serving.pipeline.api.data.Image;
-import ai.konduit.serving.pipeline.api.data.NDArray;
-import ai.konduit.serving.pipeline.api.data.NDArrayType;
-import ai.konduit.serving.pipeline.api.data.ValueType;
+import ai.konduit.serving.pipeline.api.data.*;
+import ai.konduit.serving.pipeline.impl.data.box.BBoxCHW;
+import ai.konduit.serving.pipeline.impl.data.box.BBoxXY;
 import ai.konduit.serving.pipeline.impl.data.image.Png;
 import ai.konduit.serving.pipeline.impl.data.ndarray.SerializedNDArray;
 import org.nd4j.shade.jackson.core.JsonGenerator;
@@ -99,6 +97,12 @@ public class DataJsonSerializer extends JsonSerializer<Data> {
                     List<?> list = data.getList(s, listVt);
                     writeList(jg, list, listVt);
                     break;
+                case BOUNDING_BOX:
+                    BoundingBox bb = data.getBoundingBox(s);
+                    writeBB(jg, bb);
+                    break;
+                default:
+                    throw new IllegalStateException("Value type not yet supported/implemented: " + vt);
             }
         }
 
@@ -175,6 +179,41 @@ public class DataJsonSerializer extends JsonSerializer<Data> {
         jg.writeEndObject();
     }
 
+    private void writeBB(JsonGenerator jg, BoundingBox bb) throws IOException {
+        //We'll keep it in the original format, if possible - but encode it as a X/Y format otherwise
+        jg.writeStartObject();
+        if(bb instanceof BBoxCHW){
+            BBoxCHW b = (BBoxCHW)bb;
+            jg.writeFieldName(Data.RESERVED_KEY_BB_CX);
+            jg.writeNumber(b.cx());
+            jg.writeFieldName(Data.RESERVED_KEY_BB_CY);
+            jg.writeNumber(b.cy());
+            jg.writeFieldName(Data.RESERVED_KEY_BB_H);
+            jg.writeNumber(b.h());
+            jg.writeFieldName(Data.RESERVED_KEY_BB_W);
+            jg.writeNumber(b.w());
+        } else {
+            jg.writeFieldName(Data.RESERVED_KEY_BB_X1);
+            jg.writeNumber(bb.x1());
+            jg.writeFieldName(Data.RESERVED_KEY_BB_X2);
+            jg.writeNumber(bb.x2());
+            jg.writeFieldName(Data.RESERVED_KEY_BB_Y1);
+            jg.writeNumber(bb.y1());
+            jg.writeFieldName(Data.RESERVED_KEY_BB_Y2);
+            jg.writeNumber(bb.y2());
+        }
+        if(bb.label() != null){
+            jg.writeFieldName("label");
+            jg.writeString(bb.label());
+        }
+        if(bb.probability() != null){
+            jg.writeFieldName("probability");
+            jg.writeNumber(bb.probability());
+        }
+
+        jg.writeEndObject();
+    }
+
     private void writeList(JsonGenerator jg, List<?> list, ValueType listType) throws IOException {
         int n = list.size();
         jg.writeStartArray(n);
@@ -222,6 +261,12 @@ public class DataJsonSerializer extends JsonSerializer<Data> {
                 List<Data> dataList = (List<Data>) list;
                 for (Data d : dataList) {
                     writeNestedData(jg, d);
+                }
+                break;
+            case BOUNDING_BOX:
+                List<BoundingBox> bbList = (List<BoundingBox>)list;
+                for(BoundingBox bb : bbList){
+                    writeBB(jg, bb);
                 }
                 break;
             case LIST:

--- a/konduit-serving-pipeline/src/test/java/ai/konduit/serving/pipeline/impl/data/DataJsonTest.java
+++ b/konduit-serving-pipeline/src/test/java/ai/konduit/serving/pipeline/impl/data/DataJsonTest.java
@@ -18,10 +18,7 @@
 
 package ai.konduit.serving.pipeline.impl.data;
 
-import ai.konduit.serving.pipeline.api.data.Data;
-import ai.konduit.serving.pipeline.api.data.Image;
-import ai.konduit.serving.pipeline.api.data.NDArray;
-import ai.konduit.serving.pipeline.api.data.ValueType;
+import ai.konduit.serving.pipeline.api.data.*;
 import org.junit.Test;
 import org.nd4j.common.resources.Resources;
 
@@ -68,6 +65,10 @@ public class DataJsonTest {
                     break;
                 case LIST:
                     d = Data.singletonList("myKey", Arrays.asList("some", "list", "values"), ValueType.STRING);
+                    break;
+                case BOUNDING_BOX:
+                    d = Data.singleton("myKey", BoundingBox.create(0.5, 0.4, 0.9, 1.0));
+                    d.put("myKey2", BoundingBox.createXY(0.1, 1, 0.2, 0.9, "label", 0.7));
                     break;
                 default:
                     throw new RuntimeException();
@@ -142,6 +143,11 @@ public class DataJsonTest {
                 case DATA:
                     List<Data> dataList = Arrays.asList(Data.singleton("key", "value"), Data.singletonList("key", Arrays.asList("string", "list"), ValueType.STRING));
                     d = Data.singletonList("key", dataList, ValueType.DATA);
+                    break;
+                case BOUNDING_BOX:
+                    List<BoundingBox> bbList = Arrays.asList(BoundingBox.createXY(0.2, 0.4, 0.7, 0.9, "myLabel", 0.8),
+                            BoundingBox.create(0.4, 0.5, 0.3, 0.1, "otherlabel", 0.99));
+                    d = Data.singletonList("key", bbList, ValueType.BOUNDING_BOX);
                     break;
                 default:
                     throw new RuntimeException();


### PR DESCRIPTION
Added bounding boxes as a standard datatype, that is defined in terms of:
* A tuple - (x1, x2, y1, y2, label, probability), OR
* A tuple - (cx, cy, h, w, label, probability)

We can of course represent the same values as a Data instance, but for improved usability (and more robust bounding-box-related pipeline steps), it seems better to have this as a first-class datatype.

JSON serialization implemented; protobuf not yet.

