### PR TITLE
Add segmentation drawing pipeline step

### DIFF
--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/grid/draw/DrawGridStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/grid/draw/DrawGridStepRunner.java
@@ -18,11 +18,8 @@
 
 package ai.konduit.serving.data.image.step.grid.draw;
 
-import ai.konduit.serving.data.image.convert.ImageToNDArray;
-import ai.konduit.serving.data.image.convert.ImageToNDArrayConfig;
 import ai.konduit.serving.data.image.util.ColorUtil;
 import ai.konduit.serving.pipeline.api.context.Context;
-import ai.konduit.serving.pipeline.api.data.BoundingBox;
 import ai.konduit.serving.pipeline.api.data.Data;
 import ai.konduit.serving.pipeline.api.data.Image;
 import ai.konduit.serving.pipeline.api.data.ValueType;
@@ -36,22 +33,13 @@ import org.apache.commons.math3.geometry.euclidean.twod.hull.ConvexHull2D;
 import org.apache.commons.math3.geometry.euclidean.twod.hull.MonotoneChain;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.Point;
-import org.bytedeco.opencv.opencv_core.Rect;
 import org.bytedeco.opencv.opencv_core.Scalar;
-import org.bytedeco.opencv.opencv_core.Size;
 import org.nd4j.common.base.Preconditions;
 
-import java.awt.*;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class DrawGridStepRunner implements PipelineStepRunner {
-
-    protected static final String INVALID_COLOR = "Invalid color: Must be in one of the following formats: hex/HTML - #788E87, " +
-            "RGB - rgb(128,0,255), or a color such as \"green\", etc - got \"%s\"";
-
 
 
 

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStep.java
@@ -27,19 +27,36 @@ import lombok.experimental.Accessors;
 import java.util.List;
 
 /**
- * Draw segmentation mask, optionally on an image
+ * Draw segmentation mask, optionally on an image.<br>
+ * Configuration:<br>
+ * <ul>
+ *     <li><b>classColors</b>: Optional: A list of colors to use for each class. Must be in one of the following formats: hex/HTML - "#788E87",
+ *             RGB - "rgb(128,0,255)", or one of 16 HTML color name such as \"green\" (https://en.wikipedia.org/wiki/Web_colors#HTML_color_names).
+ *             If no colors are specified, or not enough colors are specified, random colors are used instead (note consistent between runs)</li>
+ *     <li><b>segmentArray</b>: Name of the NDArray with the class indices, 0 to numClasses-1. Shape [1, height, width]</li>
+ *     <li><b>image</b>: Optional. Name of the image to draw the segmentation classes on to. If not provided, the segmentation classes are drawn
+ *     onto a black background image</li>
+ *     <li><b>outputName</b>: Name of the output image</li>
+ *     <li><b>opacity</b>: Optional. Only used when "image" configuration is set. The opacity, between 0.0 and 1.0, of the mask to draw on the image.
+ *     Default value of 0.5 if not set. Value of 0.0 is fully transparent, 1.0 is fully opaque.</li>
+ *     <li><b>backgroundClass</b>: Optional. If set: Don't draw this class. If not set: all classes will be drawn</li>
+ * </ul>
+ *
+ * @author Alex Black
  */
 @Builder
 @Data
 @Accessors(fluent = true)
 @AllArgsConstructor
 public class DrawSegmentationStep implements PipelineStep {
-
     public static final String DEFAULT_OUTPUT_NAME = "image";
+    public static final double DEFAULT_OPACITY = 0.5;
 
     private List<String> classColors;
     private String segmentArray;
     private String image;
     private String outputName;
+    private Double opacity;         //0 to 1
+    private Integer backgroundClass;
 
 }

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStep.java
@@ -1,0 +1,45 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.segmentation.index;
+
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+/**
+ * Draw segmentation mask, optionally on an image
+ */
+@Builder
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+public class DrawSegmentationStep implements PipelineStep {
+
+    public static final String DEFAULT_OUTPUT_NAME = "image";
+
+    private List<String> classColors;
+    private String segmentArray;
+    private String image;
+    private String outputName;
+
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStepRunner.java
@@ -1,0 +1,139 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.segmentation.index;
+
+import ai.konduit.serving.data.image.util.ColorUtil;
+import ai.konduit.serving.pipeline.api.context.Context;
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.Image;
+import ai.konduit.serving.pipeline.api.data.NDArray;
+import ai.konduit.serving.pipeline.api.data.NDArrayType;
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
+import ai.konduit.serving.pipeline.impl.data.ndarray.SerializedNDArray;
+import lombok.NonNull;
+import org.bytedeco.javacpp.indexer.UByteIndexer;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Scalar;
+import org.opencv.core.CvType;
+
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.util.List;
+
+public class DrawSegmentationStepRunner implements PipelineStepRunner {
+
+    protected final DrawSegmentationStep step;
+    protected Scalar[] colors;
+    protected int[] colorsB;
+    protected int[] colorsG;
+    protected int[] colorsR;
+
+    public DrawSegmentationStepRunner(@NonNull DrawSegmentationStep step) {
+        this.step = step;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public PipelineStep getPipelineStep() {
+        return step;
+    }
+
+    @Override
+    public Data exec(Context ctx, Data data) {
+        List<String> classColors = step.classColors();
+        if (colors == null && classColors != null) {
+            colors = new Scalar[classColors.size()];
+            colorsB = new int[classColors.size()];
+            colorsG = new int[classColors.size()];
+            colorsR = new int[classColors.size()];
+            for (int i = 0; i < colors.length; i++) {
+                colors[i] = ColorUtil.stringToColor(classColors.get(i));
+                int r = (int) colors[i].red();
+                int g = (int) colors[i].green();
+                int b = (int) colors[i].blue();
+                colorsB[i] = b;
+                colorsG[i] = g;
+                colorsR[i] = r;
+            }
+        }
+
+        NDArray mask = data.getNDArray(step.segmentArray());
+
+        Mat drawOn;
+        String imgName = step.image();
+
+        if (imgName == null) {
+            long[] shape = mask.shape();
+            //TODO checks for rank and shape
+            drawOn = new Mat((int) shape[1], (int) shape[2], CvType.CV_8UC3);       //8 bits per chanel RGB
+        } else {
+            Image i = data.getImage(imgName);
+            drawOn = new Mat();
+            i.getAs(Mat.class).clone().convertTo(drawOn, CvType.CV_8UC3);
+        }
+
+        SerializedNDArray nd = mask.getAs(SerializedNDArray.class);
+        long[] maskShape = nd.getShape();
+        int h = (int) maskShape[1];
+        int w = (int) maskShape[2];
+
+        //TODO ideally we'd use OpenCV's bitwise methods to do this, but it seems like JavaCV doesn't have those...
+        UByteIndexer idx = drawOn.createIndexer();      //HWC BGR format
+
+
+        IntGetter ig = null;
+        if (nd.getType() == NDArrayType.INT32) {
+            IntBuffer ib = nd.getBuffer().asIntBuffer();
+            ig = ib::get;
+        } else if (nd.getType() == NDArrayType.INT64) {
+            nd.getBuffer().rewind();
+            LongBuffer lb = nd.getBuffer().asLongBuffer();
+            ig = () -> (int)lb.get();
+        } else {
+            throw new RuntimeException();
+        }
+
+
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int classIdx = ig.get();
+                int idxB = (3 * w * y) + (3 * x);
+                idx.put(idxB, colorsB[classIdx]);
+                idx.put(idxB + 1, colorsG[classIdx]);
+                idx.put(idxB + 2, colorsR[classIdx]);
+            }
+        }
+
+
+        String outputName = step.outputName();
+        if(outputName == null)
+            outputName = DrawSegmentationStep.DEFAULT_OUTPUT_NAME;
+
+        return Data.singleton(outputName, Image.create(drawOn));
+    }
+
+    private interface IntGetter {
+        int get();
+    }
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStepRunnerFactory.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/segmentation/index/DrawSegmentationStepRunnerFactory.java
@@ -1,0 +1,39 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.segmentation.index;
+
+import ai.konduit.serving.data.image.step.grid.draw.DrawFixedGridStep;
+import ai.konduit.serving.data.image.step.grid.draw.DrawGridStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory;
+import org.nd4j.common.base.Preconditions;
+
+public class DrawSegmentationStepRunnerFactory implements PipelineStepRunnerFactory {
+    @Override
+    public boolean canRun(PipelineStep pipelineStep) {
+        return pipelineStep instanceof DrawSegmentationStep;
+    }
+
+    @Override
+    public PipelineStepRunner create(PipelineStep pipelineStep) {
+        Preconditions.checkState(canRun(pipelineStep), "Unable to run step: %s", pipelineStep);
+        return new DrawSegmentationStepRunner((DrawSegmentationStep)pipelineStep);
+    }
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/util/ColorUtil.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/util/ColorUtil.java
@@ -22,39 +22,54 @@ import org.bytedeco.opencv.opencv_core.Scalar;
 import org.nd4j.common.base.Preconditions;
 
 import java.awt.*;
+import java.util.Random;
 
 public class ColorUtil {
 
     public static final String INVALID_COLOR = "Invalid color: Must be in one of the following formats: hex/HTML - #788E87, " +
             "RGB - rgb(128,0,255), or a HTML color name such as \"green\" (https://en.wikipedia.org/wiki/Web_colors#HTML_color_names) - got \"%s\"";
 
-    private ColorUtil(){ }
+    private ColorUtil() {
+    }
 
-    public static Scalar stringToColor(String s){
-
-        if(s.startsWith("#")){
+    /**
+     * Convert a color to a Scalar in one of 3 formats:<br>
+     * hex/HTML - {@code #788E87}<br>
+     * RGB - "rgb(128,0,255)"<br>
+     * A HTML color name such as "green" (https://en.wikipedia.org/wiki/Web_colors#HTML_color_names)<br>
+     * @param s Color name
+     * @return Color
+     */
+    public static Scalar stringToColor(String s) {
+        if (s.startsWith("#")) {
             String hex = s.substring(1);
             Color c = Color.decode(hex);
             return org.bytedeco.opencv.helper.opencv_core.RGB(c.getRed(), c.getGreen(), c.getBlue());
-        } else if(s.toLowerCase().startsWith("rgb(") && s.endsWith(")")){
-            String sub = s.substring(4, s.length()-1);
+        } else if (s.toLowerCase().startsWith("rgb(") && s.endsWith(")")) {
+            String sub = s.substring(4, s.length() - 1);
             Preconditions.checkState(sub.matches("\\d+,\\d+,\\d+"), INVALID_COLOR, s);
             String[] split = sub.split(",");
             int r = Integer.parseInt(split[0]);
             int g = Integer.parseInt(split[1]);
             int b = Integer.parseInt(split[2]);
-            return org.bytedeco.opencv.helper.opencv_core.RGB(r,g,b);
+            return org.bytedeco.opencv.helper.opencv_core.RGB(r, g, b);
         } else {
             Scalar sc = getColorHTML(s);
-            if(sc == null){
+            if (sc == null) {
                 throw new UnsupportedOperationException(String.format(INVALID_COLOR, s));
             }
             return sc;
         }
     }
 
-    public static Scalar getColorHTML(String name){
-        switch (name.toLowerCase()){
+    /**
+     * Get a color from the 16 HTML color names (not case sensitive):
+     * while, silver, gray, black, red, maroon, yellow, olive, lime, green, aqua, teal, blue, navy, fuscia, purple.
+     * Returns null for any not found colors
+     * @return The color name as a Scalar, or null if not found
+     */
+    public static Scalar getColorHTML(String name) {
+        switch (name.toLowerCase()) {
             case "white":
                 return org.bytedeco.opencv.helper.opencv_core.RGB(255, 255, 255);
             case "silver":
@@ -89,6 +104,16 @@ public class ColorUtil {
                 return org.bytedeco.opencv.helper.opencv_core.RGB(0x80, 0x00, 0x80);
         }
         return null;
+    }
+
+    /**
+     * Regenate a random color using the specified RGN
+     *
+     * @param rng RNG to use
+     * @return Random color
+     */
+    public static Scalar randomColor(Random rng) {
+        return org.bytedeco.opencv.helper.opencv_core.RGB(rng.nextInt(255), rng.nextInt(255), rng.nextInt(255));
     }
 
 

--- a/konduit-serving-data/konduit-serving-image/src/main/resources/META-INF/services/ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory
+++ b/konduit-serving-data/konduit-serving-image/src/main/resources/META-INF/services/ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory
@@ -19,3 +19,4 @@ ai.konduit.serving.data.image.step.ndarray.ImageToNDArrayStepRunnerFactory
 ai.konduit.serving.data.image.step.show.ShowImageStepRunnerFactory
 ai.konduit.serving.data.image.step.bb.extract.ExtractBoundingBoxStepRunnerFactory
 ai.konduit.serving.data.image.step.grid.draw.DrawGridStepRunnerFactory
+ai.konduit.serving.data.image.step.segmentation.index.DrawSegmentationStepRunnerFactory

--- a/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawSegmentation.java
+++ b/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawSegmentation.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
 
 public class TestDrawSegmentation {
 
-    private final boolean show = true;   //Set to true to visualize
+    private final boolean show = false;   //Set to true to visualize
 
     @Test
     public void testDrawSegment() throws Exception {

--- a/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawSegmentation.java
+++ b/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawSegmentation.java
@@ -1,0 +1,70 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image;
+
+import ai.konduit.serving.data.image.step.segmentation.index.DrawSegmentationStep;
+import ai.konduit.serving.data.image.step.show.ShowImagePipelineStep;
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.NDArray;
+import ai.konduit.serving.pipeline.api.pipeline.Pipeline;
+import ai.konduit.serving.pipeline.impl.pipeline.SequencePipeline;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+
+import java.util.Arrays;
+
+public class TestDrawSegmentation {
+
+    @Test
+    @Ignore
+    public void testDrawSegment() throws Exception {
+
+
+        Pipeline p = SequencePipeline.builder()
+                .add(DrawSegmentationStep.builder()
+                        .image(null)
+                        .segmentArray("class_idxs")
+                        .outputName("out")
+                        .classColors(Arrays.asList("red", "green", "blue"))
+                        .build())
+                .add(ShowImagePipelineStep.builder()
+                        .displayName("Segment")
+                        .imageName("out")
+                        .width(256)
+                        .height(256)
+                        .build())
+                .build();
+
+        //Segmentation indices array: [minibatch, height, width] - values are integers,
+        INDArray arr = Nd4j.create(DataType.INT32, 1, 64, 64);                                              //Red background
+        arr.get(NDArrayIndex.point(0), NDArrayIndex.interval(16, 48), NDArrayIndex.interval(16, 48)).assign(1);     //Green square in middle
+        arr.get(NDArrayIndex.point(0), NDArrayIndex.interval(32, 64), NDArrayIndex.interval(32, 64)).assign(2);     //Blue square in bottom right
+
+        Data d = Data.singleton("class_idxs", NDArray.create(arr));
+
+        p.executor().exec(d);
+
+        Thread.sleep(100000);
+    }
+
+}

--- a/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestTensorFlowStep.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestTensorFlowStep.java
@@ -325,6 +325,7 @@ public class TestTensorFlowStep {
 
         //Post process SSD outputs to BoundingBox objects
         GraphStep ssdProc = tf.then("bbox", SSDToBoundingBoxStep.builder()
+                .threshold(0.6)
                 .outputName("img_bbox")
                 .build());
 

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/ml/ssd/SSDToBoundingBoxRunner.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/ml/ssd/SSDToBoundingBoxRunner.java
@@ -33,7 +33,7 @@ import java.util.List;
 @AllArgsConstructor
 public class SSDToBoundingBoxRunner implements PipelineStepRunner {
 
-    private SSDToBoundingBoxStep step;
+    protected final SSDToBoundingBoxStep step;
 
     @Override
     public void close() {
@@ -48,7 +48,7 @@ public class SSDToBoundingBoxRunner implements PipelineStepRunner {
     @Override
     public Data exec(Context ctx, Data data) {
 
-        double threshold = 0.5;
+        double threshold = step.threshold();
 
         String key = "detection_boxes";     //TODO
         String prob = "detection_scores";

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/ml/ssd/SSDToBoundingBoxStep.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/ml/ssd/SSDToBoundingBoxStep.java
@@ -37,6 +37,9 @@ public class SSDToBoundingBoxStep implements PipelineStep {
     protected boolean keepOtherValues = true;
 
     @Builder.Default
+    protected double threshold = 0.5;
+
+    @Builder.Default
     protected String outputName = DEFAULT_OUTPUT_NAME;
 
     public SSDToBoundingBoxStep(){
@@ -44,6 +47,7 @@ public class SSDToBoundingBoxStep implements PipelineStep {
         //Without setting defaults here again like this, the fields would actually be null
         this.keepOtherValues = true;
         this.outputName = DEFAULT_OUTPUT_NAME;
+        this.threshold = 0.5;
     }
 
 }


### PR DESCRIPTION
Can draw the segmentation results as specified colors on a blank canvas.
Assumes input array is a [1, h, w], with h/w matching image (when image is provided).
See DrawSegmentationStep for full details of the configuration and options.

Also adds threshold configuration for SSD.

![image](https://user-images.githubusercontent.com/2360237/82518251-4a11c400-9b62-11ea-8daa-804981c2f58d.png)
