### PR TITLE
Switch TF to javacpp presets (and 1.15.0 -> 1.15.2) [WIP]

### DIFF
--- a/konduit-serving-models/konduit-serving-tensorflow/pom.xml
+++ b/konduit-serving-models/konduit-serving-tensorflow/pom.xml
@@ -31,9 +31,34 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.tensorflow</groupId>
+            <groupId>org.bytedeco</groupId>
             <artifactId>tensorflow</artifactId>
-            <version>1.15.0</version>
+            <version>1.15.2-1.5.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>tensorflow</artifactId>
+            <version>1.15.2-1.5.3</version>
+            <classifier>${javacpp.platform}</classifier>
+        </dependency>
+
+        <!-- NOTE: Clearly mkl-dnn will NOT work for non-x86 systems. These should be in a property, but profile activation
+          for tests doesn't seem to work... putting these in a profile with <activation><property><name>os.arch</name><value>x86_64</value></property></activation>
+          does not work (profile is not activated according to mvn help:active-profiles, or by mvn dependency:tree, or during tests (unsatisfied link errors)
+          even though the os.arch==x86_64 system property is definitely set, according to approach used here: https://florianlr.wordpress.com/2012/04/24/16/
+         -->
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>mkl-dnn</artifactId>
+            <version>${mkl-dnn.javacpp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>mkl-dnn</artifactId>
+            <version>${mkl-dnn.javacpp.version}</version>
+            <classifier>${javacpp.platform}</classifier>
         </dependency>
 
         <dependency>
@@ -90,6 +115,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/format/TFNDArray.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/format/TFNDArray.java
@@ -21,12 +21,18 @@ package ai.konduit.serving.models.tensorflow.format;
 import ai.konduit.serving.models.tensorflow.util.TensorFlowUtil;
 import ai.konduit.serving.pipeline.api.data.NDArrayType;
 import ai.konduit.serving.pipeline.impl.data.ndarray.BaseNDArray;
+import org.bytedeco.tensorflow.TF_Graph;
 import org.tensorflow.DataType;
 import org.tensorflow.Tensor;
 
 import java.util.Arrays;
 
 public class TFNDArray extends BaseNDArray<Tensor> {
+
+    static {
+        TensorFlowUtil.ensureNativeLibrariesLoaded();
+    }
+
     public TFNDArray(Tensor array) {
         super(array);
     }

--- a/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/format/TensorFlowConverters.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/format/TensorFlowConverters.java
@@ -34,10 +34,16 @@ import java.nio.ByteOrder;
 
 public class TensorFlowConverters {
 
+    static {
+        TensorFlowUtil.ensureNativeLibrariesLoaded();
+    }
+
     private TensorFlowConverters(){ }
 
     @AllArgsConstructor
     public static class SerializedToTensorFlowConverter implements NDArrayConverter {
+        static { TensorFlowUtil.ensureNativeLibrariesLoaded(); }
+
         @Override
         public boolean canConvert(NDArray from, NDArrayFormat to) {
             return canConvert(from, to.formatType());
@@ -74,6 +80,7 @@ public class TensorFlowConverters {
 
     @AllArgsConstructor
     public static class TensorFlowToSerializedConverter implements NDArrayConverter {
+        static { TensorFlowUtil.ensureNativeLibrariesLoaded(); }
         @Override
         public boolean canConvert(NDArray from, NDArrayFormat to) {
             return canConvert(from, to.formatType());

--- a/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/step/TensorFlowStepRunner.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/step/TensorFlowStepRunner.java
@@ -18,6 +18,7 @@
 
 package ai.konduit.serving.models.tensorflow.step;
 
+import ai.konduit.serving.models.tensorflow.util.TensorFlowUtil;
 import ai.konduit.serving.pipeline.api.context.Context;
 import ai.konduit.serving.pipeline.api.data.Data;
 import ai.konduit.serving.pipeline.api.data.NDArray;
@@ -26,6 +27,7 @@ import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.bytedeco.tensorflow.TF_Graph;
 import org.nd4j.common.base.Preconditions;
 import org.tensorflow.Graph;
 import org.tensorflow.SavedModelBundle;
@@ -38,6 +40,11 @@ import java.util.List;
 
 @Slf4j
 public class TensorFlowStepRunner implements PipelineStepRunner {
+
+    static {
+        TensorFlowUtil.ensureNativeLibrariesLoaded();
+    }
+
 
     private final TensorFlowPipelineStep step;
     private Graph graph;

--- a/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/util/TensorFlowUtil.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/util/TensorFlowUtil.java
@@ -19,8 +19,11 @@
 package ai.konduit.serving.models.tensorflow.util;
 
 import ai.konduit.serving.pipeline.api.data.NDArrayType;
+import org.bytedeco.tensorflow.TF_Graph;
 import org.tensorflow.DataType;
 import org.tensorflow.types.UInt8;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TensorFlowUtil {
 
@@ -74,6 +77,15 @@ public class TensorFlowUtil {
                 return NDArrayType.BOOL;
             default:
                 throw new UnsupportedOperationException("Unknown TF type: " + dataType);
+        }
+    }
+
+    private static final AtomicBoolean loaded = new AtomicBoolean();
+    public static void ensureNativeLibrariesLoaded(){
+        if(!loaded.get()){
+            //Ensure TF binaries are loaded
+            TF_Graph.newGraph().close();
+            loaded.set(true);
         }
     }
 

--- a/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestArrayConversion.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestArrayConversion.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 public class TestArrayConversion {
 
     @Test
-    public void testConversion(){
+    public void testConversion() throws Exception {
 
         for(NDArrayType t : new NDArrayType[]{
                 NDArrayType.DOUBLE,

--- a/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestTensorFlowStep.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestTensorFlowStep.java
@@ -26,7 +26,6 @@ import ai.konduit.serving.data.image.step.bb.draw.DrawBoundingBoxStep;
 import ai.konduit.serving.data.image.step.ndarray.ImageToNDArrayStep;
 import ai.konduit.serving.data.image.step.segmentation.index.DrawSegmentationStep;
 import ai.konduit.serving.data.image.step.show.ShowImagePipelineStep;
-import ai.konduit.serving.models.tensorflow.step.TensorFlowPipelineStep;
 import ai.konduit.serving.pipeline.api.data.BoundingBox;
 import ai.konduit.serving.pipeline.api.data.Data;
 import ai.konduit.serving.pipeline.api.data.Image;
@@ -52,7 +51,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static ai.konduit.serving.models.tensorflow.step.TensorFlowPipelineStep.*;
+import static ai.konduit.serving.models.tensorflow.step.TensorFlowPipelineStep.builder;
 import static org.junit.Assert.assertEquals;
 
 @Slf4j
@@ -154,7 +153,6 @@ public class TestTensorFlowStep {
 
     @Test
     public void testFrozenModel() throws Exception {
-
         //Pretrained model source: https://github.com/yeephycho/tensorflow-face-detection
         String fileUrl = "https://drive.google.com/uc?export=download&id=0B5ttP5kO_loUdWZWZVVrN2VmWFk";
         File testDir = TestUtils.testResourcesStorageDir();

--- a/konduit-serving-vertx-protocols/konduit-serving-grpc/pom.xml
+++ b/konduit-serving-vertx-protocols/konduit-serving-grpc/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <xolstice.protobuf-maven-plugin.version>0.6.1</xolstice.protobuf-maven-plugin.version>
         <vertx.protoc-gen-grpc-java.version>1.25.0</vertx.protoc-gen-grpc-java.version>
-        <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
         <fastutil.version>8.1.1</fastutil.version>
         <protobuf.version>3.8.0</protobuf.version>
         <error_prone_annotations.version>2.3.3</error_prone_annotations.version>
+        <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This works, but:
* TensorFlowUtil.ensureNativeLibrariesLoaded(); - maybe a better approach is available? (`@Platform` annotation maybe, but we need to ensure the annotated class is guaranteed to be loaded before anything that uses TF...
* mkl-dnn (necessary for x86) should be in a profile to enable to build on non-x86 systems, but I couldn't get the profile to activate during tests based on os.arch property (which is definitely set correctly)