### PR TITLE
CLI server dependencies resolution (no uber-JARs for CLI launching)

### DIFF
--- a/ADRs/0006_CI_Launching_vs_Build.md
+++ b/ADRs/0006_CI_Launching_vs_Build.md
@@ -109,32 +109,28 @@ Use <some_command> to set default profile or pass "-p <profile>" when launching 
 Launching server using default device profile "CUDA_10.2"
 Acquiring dependencies... done
 
-<usual Koanduti Serving launch info>
+<usual Konduit Serving launch info>
 ```
 
-Note that users need only 2 lines here to go from a brand new system to hosting a model server using the optimal hardware.
-Furthermore, other than downloading dependencies, there is no slow "build uberjar" step that delays the launching of the
-server by 30-120 seconds.
+Note that users need only 2 lines here to go from a brand new system (no KS install) to hosting a model server using the
+ optimal hardware/configuration for that device (i.e., CUDA, or highest supported AVX level for x86 systems, etc).
+Furthermore there is no slow "build uberjar" step that delays the launching of the server by 30-120 seconds, on top of
+dependency downloading.
 
 ### Launching for the "Deployment Artifact" case 
 
-This "manifest JAR" approach can likely be used 
+This "manifest JAR" approach can likely be used in other situations:
 
-* Docker: Could use either uber-JAR or switching to an assembly-JAR style  
-* RPM and DEB:
-* Stand-alone .exe: Continue to use uber-JAR approach 
+* Docker: Could use either uber-JAR or switching to an assembly-JAR style (i.e., embed the original/unmodified dependency
+  JARs instead of an uberjar)  
+* RPM and DEB: As per docker
+* Stand-alone .exe: Continue to use uber-JAR approach
+
+If we decide an assembly-JAR style approach is useful for these deployment artifacts, we can implement that at a later date.
  
-
-Open question: Why do we even need uberjars??
-Can we do everything we need via this "gradle cache" (or an assembly jar) approach?
--> Docker images could just include the JARs. Does an uberjar actually help here?
-In fact it has the downside of being limited to only one 
-
-Do "fixed" deployments even make sense? i.e., we can only ever run this pipeline (or ones with the exact same modules) with it.
-"Minimal size for this deployment" does make sense, yes. But why not just resolve the extra dependencies automatically
-if the user tries to run something else with it?
-
-Also, in principle we can add extra depnedencies on top of an uberjar... it's not super elegant, but it should work.
+Also, in principle we can add extra dependencies on top of an uberjar... it may not be an especially elegant design, but
+combining uber-jars with 'extra' classpath dependencies may be possible if we ever really need it. However that won't
+be something we support for now
 
 ### Detecting Hardware and Creating Profiles
 

--- a/ADRs/0006_CI_Launching_vs_Build.md
+++ b/ADRs/0006_CI_Launching_vs_Build.md
@@ -1,0 +1,191 @@
+# CLI Dependencies and Launching
+
+## Status
+PROPOSED - 08/06/2020
+
+Proposed by: Alex Black (08/06/2020)
+
+Discussed with:
+
+## Context
+
+There are multiple ways a user might want to use Konduit Serving to serve a model.
+For the sake of this ADR, I'll refer to two use cases as:
+1. Immediate deployment case: "Deploy a server for this pipeline right now on this machine via the CLI"
+2. Deployment artifact case: "Create an artifact (JAR, docker image, etc) for deployment somewhere else"
+
+The ADR 0005-Packaging_System_Design.md dealt with the "create deployment artifact" (2) case above.  
+However, the build system in its current form it does well not serve the needs of the immediate deployment use case 
+particularly well, mainly due to its uber-jar design. This causes a few usability problems:
+1. Deploying a pipeline with different modules (dl4j vs. samediff vs. TF, or CPU vs. GPU) requires building an uber-jar
+2. Uber-jar builds can take a long time (30-120+ seconds, plus download time)
+3. Either we always rebuild (slow launches) or we have an uber-JAR cache (potentially lots of unnecessary disk space used)
+
+The old API CLI dependency/launching approach for this use case also had/has the following problems:
+1. Requiring the user to build a JAR ahead of time and manually include the modules they need
+2. Not being able to launch (for example) both CPU and GPU servers simultaneously without rebuilding the whole Konduit
+   Serving uber-jar in between launching the different servers
+
+For the CLI-based "deploy right now" use case, an alternative is proposed.
+
+## Proposal
+
+For the "immediate deployment via CLI" scenario, we will not create an uber-jar; instead, we will use the Konduit Serving
+build tool to work out the dependencies we need, download them, and return a list of all dependencies (i.e., a list of JAR file
+paths) that the Konduit Serving server will be launched with.
+
+This is similar to how IDEs like IntelliJ work. Consider for example the command IntelliJ uses when launching unit tests etc: (some parts omitted)
+```
+"C:\Program Files\AdoptOpenJDK\jdk-8.0.242.08-hotspot\bin\java.exe" -ea -Dfile.encoding=UTF-8 -classpath "C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2019.3.3\lib\idea_rt.jar;...;C:\DL4J\git\konduit-serving\konduit-serving-models\konduit-serving-deeplearning4j\target\test-classes;...;C:\Users\Alex\.m2\repository\org\nd4j\nd4j-api\1.0.0-beta7\nd4j-api-1.0.0-beta7.jar;C:\Users\Alex\.m2\repository\com\jakewharton\byteunits\byteunits\0.9.1\byteunits-0.9.1.jar;C:\Users\Alex\.m2\repository\com\google\flatbuffers\flatbuffers-java\1.10.0\flatbuffers-java-1.10.0.jar;C:\Users\Alex\.m2\repository\org\nd4j\protobuf\1.0.0-beta7\protobuf-1.0.0-beta7.jar;C:\Users\Alex\.m2\repository\commons-net\commons-net\3.1\commons-net-3.1.jar... " com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit4 ai.konduit.serving.deeplearning4j.TestDL4JModelStep
+```
+Note the `-classpath "<list of JAR paths>"` component here.
+
+In practice, we won't pass a list of JAR file paths directly due to constraints on the maximum command line length on Windows.  
+Instead, we will use a small JAR containing a manifest file, which will list the absolute path of all dependencies:
+https://www.baeldung.com/java-jar-manifest  
+This single manifest JAR is then passed via the `-classpath <path>` arg during launch.
+
+Note that this exact Manifest JAR approach is also used by IntelliJ as an option for command line shortening to work around
+the maximum command line length problem.
+    
+
+The key aspects of this design:
+**1 - Static CLI JAR**
+The CLI JAR is a static JAR without any modules/dependencies that are needed to run pipeline steps; it never gets modified,
+rebuilt, etc no matter what type of pipeline is being launched.
+
+**2 - Konduit Serving Build Tool - Downloads and Resolves Dependencies**
+
+When a user launches a server based on some Konduit Serving pipeline configuration, the following occurs:
+1. The CLI calls the build tool
+2. The build tool resolves all dependencies that need to be included to run that pipeline
+3. All direct and transitive dependencies are downloaded as normal via Gradle and stored in their usual location
+4. The build tool creates the required manifest JAR
+
+**3 - We introduce a concept of "device profiles" in the CLI**
+
+In practice, this will allow users to switch between different targets when launching (CPU vs. CUDA, and x86 instead of x86_AVX2 if needed
+for some reason). Specifically:
+1. On the first run of the Konduit Serving CLI, we automatically create a set of appropriate device profiles based on
+   hardware and software available on this system. We will also set the default device profile to the CUDA profile if present.   
+   In practice, this will usually be just a CPU profile (highest level supported - avx2, avx512, etc) and a CUDA profile
+   if a CUDA device is present on the system. For the CUDA profile, we'll also detect if the CUDA is installed (if not,
+   we'll use the JavaCPP presets CUDA redist binaries to provide it at runtime, avoiding the need for a manual install)
+2. When running, we'll use the default profile unless the user passes a `-p <profile_name>` during launch. That is:  
+   `konduit serve -c config.json -p CPU`
+
+In practice most users won't need to worry about device profiles, unless they need:  
+(a) to run on CPU only for a GPU-enabled device, or
+(b) (very rarely, if ever) need to downgrade the target (for example, x86 instead of x86_avx2 on an avx2 compatible system)
+    as a workaround to some issue with an avx2 or higher binary.  
+
+### Example Workflow: Launch Locally
+
+Suppose a user wants to deploy a server for inference, on system without a Konduit Serving installation.  
+Here's what that could look like:
+
+```text
+$ pip install konduit-serving           #Or any other easy installation method - apt, yum, etc etc
+
+$ konduit serve -c config.json
+
+Konduit Serving
+--- Konduit Serving First Run Initialization ---
+Detecting hardware... done
+  CPU:                 ARM64 (aarch64) - 4 core
+  CUDA GPU:            <device name>, 4GB
+  CUDA installation:   Found CUDA 10.2 (/usr/local/cuda)
+
+Creating device profiles...
+  Profile 1: "CUDA_10.2" - ARM64, CUDA 10.2 installed 
+  Profile 2: "CPU"       - ARM64, CPU execution
+Creating device profiles complete
+
+Setting default profile: "CUDA_10.2"
+
+Use <some_command> to set default profile or pass "-p <profile>" when launching to override
+--- First run initialization complete ---
+
+Launching server using default device profile "CUDA_10.2"
+Acquiring dependencies... done
+
+<usual Koanduti Serving launch info>
+```
+
+Note that users need only 2 lines here to go from a brand new system to hosting a model server using the optimal hardware.
+Furthermore, other than downloading dependencies, there is no slow "build uberjar" step that delays the launching of the
+server by 30-120 seconds.
+
+### Launching for the "Deployment Artifact" case 
+
+This "manifest JAR" approach can likely be used 
+
+* Docker: Could use either uber-JAR or switching to an assembly-JAR style  
+* RPM and DEB:
+* Stand-alone .exe: Continue to use uber-JAR approach 
+ 
+
+Open question: Why do we even need uberjars??
+Can we do everything we need via this "gradle cache" (or an assembly jar) approach?
+-> Docker images could just include the JARs. Does an uberjar actually help here?
+In fact it has the downside of being limited to only one 
+
+Do "fixed" deployments even make sense? i.e., we can only ever run this pipeline (or ones with the exact same modules) with it.
+"Minimal size for this deployment" does make sense, yes. But why not just resolve the extra dependencies automatically
+if the user tries to run something else with it?
+
+Also, in principle we can add extra depnedencies on top of an uberjar... it's not super elegant, but it should work.
+
+### Detecting Hardware and Creating Profiles
+
+Detecting the CPU details should be straightforward, at least on x86-based systems using a library such as OSHI:
+https://github.com/oshi/oshi
+How well OSHI supports ARM-based platforms is something we need to explore, though Raspberry Pi (armhf) support does
+seem to be available: https://github.com/oshi/oshi/issues/864
+Falling back on a system utility (`cat /proc/cpuinfo` or similar) is also a possibility here.
+
+Detecting the presence or absence of a compatible CUDA GPU may be harder. When CUDA is installed and available on the
+path, this becomes easier (CUDA install -> assume CUDA device present, or parse output of `nvidia-smi`).  
+For the "no CUDA installed but CUDA GPU available" case, OSHI may show it up, or there may be a command line based approach
+to find it (like cpuinfo).  
+
+In principle this is a solveable problem but additional work is required to find a robust solution for detecting hardware
+(including CUDA GPUs, and maybe other GPUs in the future) that will work across all devices and operating systems we expect
+to deploy on in practice.
+
+
+
+## Consequences
+
+### Advantages
+
+* 2 commands to go from "no Konduit Serving" to "Server Launched"
+* Faster builds (no uber-JAR build)
+* Less disk space (no uber-JARs with redundant )
+* Easily allows mixing CPU and GPU deployments on the one system
+* No need to distribute "pre-built" binaries
+* A variant of this idea should be adaptable for use with OSGi if/when we need it
+
+### Disadvantages
+
+* Relying on JARs in Gradle/Maven caches (rarely - might cause a problem if user tries an install or similar command while a server is running?)
+* Relies on the build tool hence Gradle (maybe a problem for 'offline/no network' or 'space restricted' deployment scenarios)
+  For 'no network' deployments: we probably need to bundle Gradle itself, not just gradlew, then use `gradle --offline`  
+  However, we can still use uber-jar style deployments instead of CLI-style deployments in this scenario
+
+
+
+
+
+
+
+
+
+
+* No uber-jar building when launchi
+    - Much faster launches (especially when )
+    - No additional space required for uber-jars
+    - 
+
+
+### Disadvantages

--- a/ADRs/0006_CI_Launching_vs_Build.md
+++ b/ADRs/0006_CI_Launching_vs_Build.md
@@ -1,11 +1,11 @@
 # CLI Dependencies and Launching
 
 ## Status
-PROPOSED - 08/06/2020
+ACCEPTED - 09/06/2020
 
 Proposed by: Alex Black (08/06/2020)
 
-Discussed with:
+Discussed with: Shams
 
 ## Context
 
@@ -28,7 +28,7 @@ The old API CLI dependency/launching approach for this use case also had/has the
 
 For the CLI-based "deploy right now" use case, an alternative is proposed.
 
-## Proposal
+## Decision
 
 For the "immediate deployment via CLI" scenario, we will not create an uber-jar; instead, we will use the Konduit Serving
 build tool to work out the dependencies we need, download them, and return a list of all dependencies (i.e., a list of JAR file
@@ -157,7 +157,7 @@ to deploy on in practice.
 
 * 2 commands to go from "no Konduit Serving" to "Server Launched"
 * Faster builds (no uber-JAR build)
-* Less disk space (no uber-JARs with redundant )
+* Less disk space (no uber-JARs with redundant copies of dependencies)
 * Easily allows mixing CPU and GPU deployments on the one system
 * No need to distribute "pre-built" binaries
 * A variant of this idea should be adaptable for use with OSGi if/when we need it

--- a/ADRs/0006_CI_Launching_vs_Build.md
+++ b/ADRs/0006_CI_Launching_vs_Build.md
@@ -174,18 +174,3 @@ to deploy on in practice.
   However, we can still use uber-jar style deployments instead of CLI-style deployments in this scenario
 
 
-
-
-
-
-
-
-
-
-* No uber-jar building when launchi
-    - Much faster launches (especially when )
-    - No additional space required for uber-jars
-    - 
-
-
-### Disadvantages

--- a/konduit-serving-build/src/main/java/ai/konduit/serving/build/build/GradlePlugin.java
+++ b/konduit-serving-build/src/main/java/ai/konduit/serving/build/build/GradlePlugin.java
@@ -1,0 +1,31 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.build.build;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+public class GradlePlugin {
+    private String id;
+    private String version;
+}

--- a/konduit-serving-build/src/main/java/ai/konduit/serving/build/cli/BuildCLI.java
+++ b/konduit-serving-build/src/main/java/ai/konduit/serving/build/cli/BuildCLI.java
@@ -277,7 +277,7 @@ public class BuildCLI {
 
         System.out.println("Starting build...");
         long start = System.currentTimeMillis();
-        GradleBuild.runGradleBuild(tempDir);
+        GradleBuild.runGradleBuild(tempDir, c);
         long end = System.currentTimeMillis();
 
         System.out.println(">> Build complete\n\n");

--- a/konduit-serving-build/src/main/java/ai/konduit/serving/build/config/Deployment.java
+++ b/konduit-serving-build/src/main/java/ai/konduit/serving/build/config/Deployment.java
@@ -18,6 +18,7 @@
 
 package ai.konduit.serving.build.config;
 
+import ai.konduit.serving.build.build.GradlePlugin;
 import ai.konduit.serving.build.deployments.UberJarDeployment;
 import org.nd4j.shade.jackson.annotation.JsonSubTypes;
 import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
@@ -25,7 +26,6 @@ import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
 import java.util.List;
 import java.util.Map;
 
-import static org.nd4j.shade.jackson.annotation.JsonTypeInfo.As.PROPERTY;
 import static org.nd4j.shade.jackson.annotation.JsonTypeInfo.Id.NAME;
 
 @JsonSubTypes({
@@ -62,4 +62,9 @@ public interface Deployment {
      */
     String outputString();
 
+    List<String> gradleImports();
+
+    List<GradlePlugin> gradlePlugins();
+
+    String gradleTaskName();
 }

--- a/konduit-serving-build/src/main/java/ai/konduit/serving/build/deployments/ClassPathDeployment.java
+++ b/konduit-serving-build/src/main/java/ai/konduit/serving/build/deployments/ClassPathDeployment.java
@@ -1,0 +1,106 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.build.deployments;
+
+import ai.konduit.serving.build.config.Deployment;
+import ai.konduit.serving.build.config.DeploymentValidation;
+import ai.konduit.serving.build.config.SimpleDeploymentValidation;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Slf4j
+@Data
+@Accessors(fluent = true)
+public class ClassPathDeployment implements Deployment {
+    public enum Type {
+        TEXT_FILE,
+        JAR_MANIFEST
+    }
+
+    public static final String OUTPUT_FILE_PROP = "classpath.outputFile";
+    public static final String TYPE_PROP = "classpath.type";
+
+    private String outputFile;
+    private Type type;
+
+    @Override
+    public List<String> propertyNames() {
+        return Arrays.asList(OUTPUT_FILE_PROP, TYPE_PROP);
+    }
+
+    @Override
+    public Map<String, String> asProperties() {
+        Map<String,String> map = new HashMap<>();
+        map.put(OUTPUT_FILE_PROP, outputFile);
+        map.put(TYPE_PROP, type == null ? null : type.toString());
+        return map;
+    }
+
+    @Override
+    public void fromProperties(Map<String, String> props) {
+        outputFile = props.getOrDefault(OUTPUT_FILE_PROP, outputFile);
+        if(props.containsKey(TYPE_PROP)){
+            type = Type.valueOf(props.get(TYPE_PROP).toUpperCase());
+        }
+    }
+
+    @Override
+    public DeploymentValidation validate() {
+        if (outputFile != null && !outputFile.isEmpty() && type != null) {
+            return new SimpleDeploymentValidation();
+        }
+        List<String> errs = new ArrayList<>();
+        if(outputFile == null || outputFile.isEmpty()){
+            errs.add("Output classpath file (" + OUTPUT_FILE_PROP + " property) is not set");
+        }
+        if(type == null){
+            errs.add("Output classpath file type - " + Type.TEXT_FILE + " or " + Type.JAR_MANIFEST + " (" + TYPE_PROP + " property) is not set");
+        } else if(type == Type.JAR_MANIFEST && outputFile != null && !outputFile.endsWith(".jar")){
+            errs.add("Output classpath file (JAR_MANIFEST type) output file name (" + TYPE_PROP + " property) must end with .jar, got \"" + outputFile + "\"");
+        }
+        return new SimpleDeploymentValidation(errs);
+    }
+
+    @Override
+    public String outputString() {
+        File f = new File(outputFile);
+        StringBuilder sb = new StringBuilder();
+        sb.append("Classpath file location:        ").append(f.getAbsolutePath()).append("\n");
+        String nLines;
+        if (f.exists()) {
+            try {
+                nLines = String.valueOf(FileUtils.readLines(f, StandardCharsets.UTF_8).size());
+            } catch (IOException e) {
+                nLines = "<Error reading generated classpath file>";
+                log.warn("Error reading generated classpath file", e);
+            }
+        } else {
+            nLines = "<output file not found>";
+        }
+        sb.append("Number of classpath entries:    ").append(nLines).append("\n");
+        return sb.toString();
+    }
+}

--- a/konduit-serving-build/src/main/java/ai/konduit/serving/build/deployments/ClassPathDeployment.java
+++ b/konduit-serving-build/src/main/java/ai/konduit/serving/build/deployments/ClassPathDeployment.java
@@ -18,6 +18,7 @@
 
 package ai.konduit.serving.build.deployments;
 
+import ai.konduit.serving.build.build.GradlePlugin;
 import ai.konduit.serving.build.config.Deployment;
 import ai.konduit.serving.build.config.DeploymentValidation;
 import ai.konduit.serving.build.config.SimpleDeploymentValidation;
@@ -102,5 +103,20 @@ public class ClassPathDeployment implements Deployment {
         }
         sb.append("Number of classpath entries:    ").append(nLines).append("\n");
         return sb.toString();
+    }
+
+    @Override
+    public List<String> gradleImports() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<GradlePlugin> gradlePlugins() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String gradleTaskName() {
+        return "build";
     }
 }

--- a/konduit-serving-build/src/main/java/ai/konduit/serving/build/deployments/UberJarDeployment.java
+++ b/konduit-serving-build/src/main/java/ai/konduit/serving/build/deployments/UberJarDeployment.java
@@ -18,6 +18,7 @@
 
 package ai.konduit.serving.build.deployments;
 
+import ai.konduit.serving.build.build.GradlePlugin;
 import ai.konduit.serving.build.config.Deployment;
 import ai.konduit.serving.build.config.DeploymentValidation;
 import ai.konduit.serving.build.config.SimpleDeploymentValidation;
@@ -122,5 +123,20 @@ public class UberJarDeployment implements Deployment {
         sb.append("JAR size:            ").append(size).append("\n");
         sb.append("JAR launch command:  java -cp konduit-serving-deployment.jar <TODO args>\n");
         return sb.toString();
+    }
+
+    @Override
+    public List<String> gradleImports() {
+        return Collections.singletonList("com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar");
+    }
+
+    @Override
+    public List<GradlePlugin> gradlePlugins() {
+        return Collections.singletonList(new GradlePlugin("com.github.johnrengelman.shadow", "2.0.4"));
+    }
+
+    @Override
+    public String gradleTaskName() {
+        return "shadowJar";
     }
 }

--- a/konduit-serving-build/src/test/java/ai/konduit/serving/build/TestGradleGeneration.java
+++ b/konduit-serving-build/src/test/java/ai/konduit/serving/build/TestGradleGeneration.java
@@ -21,6 +21,7 @@ package ai.konduit.serving.build;
 import ai.konduit.serving.build.config.*;
 import ai.konduit.serving.build.config.Target;
 import ai.konduit.serving.build.dependencies.Dependency;
+import ai.konduit.serving.build.deployments.ClassPathDeployment;
 import ai.konduit.serving.build.deployments.UberJarDeployment;
 import ai.konduit.serving.build.build.GradleBuild;
 import ai.konduit.serving.models.deeplearning4j.step.DL4JModelPipelineStep;
@@ -52,8 +53,10 @@ public class TestGradleGeneration {
                 .build();
 
         File dir = testDir.newFolder();
+//        File dir = new File("C:/Temp/Gradle");
         File jsonF = new File(dir, "pipeline.json");
         FileUtils.writeStringToFile(jsonF, p.toJson(), StandardCharsets.UTF_8);
+
 
         File gradeDir = new File(dir, "gradle");
         File uberJarDir = new File(dir, "uberjar");
@@ -63,7 +66,10 @@ public class TestGradleGeneration {
                 .pipelinePath(jsonF.getAbsolutePath())
                 .target(Target.LINUX_X86)
                 .serving(Serving.HTTP)
-                .deployments(new UberJarDeployment().outputDir(uberJarDir.getAbsolutePath()).jarName("my.jar"));
+                .deployments(
+                        new UberJarDeployment().outputDir(uberJarDir.getAbsolutePath()).jarName("my.jar"),
+                        new ClassPathDeployment().outputFile("C:/Temp/Gradle/classpath.txt")
+                        );
 
         GradleBuild.generateGradleBuildFiles(gradeDir, c);
 

--- a/konduit-serving-build/src/test/java/ai/konduit/serving/build/TestGradleGeneration.java
+++ b/konduit-serving-build/src/test/java/ai/konduit/serving/build/TestGradleGeneration.java
@@ -32,6 +32,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.nd4j.common.util.ArchiveUtils;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -66,10 +67,7 @@ public class TestGradleGeneration {
                 .pipelinePath(jsonF.getAbsolutePath())
                 .target(Target.LINUX_X86)
                 .serving(Serving.HTTP)
-                .deployments(
-                        new UberJarDeployment().outputDir(uberJarDir.getAbsolutePath()).jarName("my.jar"),
-                        new ClassPathDeployment().outputFile("C:/Temp/Gradle/classpath.txt")
-                        );
+                .deployments(new UberJarDeployment().outputDir(uberJarDir.getAbsolutePath()).jarName("my.jar"));
 
         GradleBuild.generateGradleBuildFiles(gradeDir, c);
 
@@ -92,11 +90,63 @@ public class TestGradleGeneration {
 
         //Actually run the build
         //TODO this might not be doable in a unit test (unless all modules have been installed to local maven repo first)
-        GradleBuild.runGradleBuild(gradeDir);
+        GradleBuild.runGradleBuild(gradeDir, c);
 
 
         //Check output JAR exists
         File expUberJar = new File(uberJarDir, "my.jar");
         assertTrue(expUberJar.exists());
+    }
+
+    @Ignore
+    @Test
+    public void testManifestJarCreation() throws Exception {
+        Pipeline p = SequencePipeline.builder()
+                .add(new DL4JModelPipelineStep("file:///some/model/path.zip", null, null))
+                .build();
+
+        File dir = testDir.newFolder();
+//        File dir = new File("C:/Temp/Gradle");
+        File jsonF = new File(dir, "pipeline.json");
+        FileUtils.writeStringToFile(jsonF, p.toJson(), StandardCharsets.UTF_8);
+
+        File gradeDir = new File(dir, "gradle");
+        File mfJar = new File(dir, "myManifestJar.jar");
+
+        Config c = new Config()
+                .pipelinePath(jsonF.getAbsolutePath())
+                .target(Target.LINUX_X86)
+                .serving(Serving.HTTP)
+                .deployments(
+                        new ClassPathDeployment().type(ClassPathDeployment.Type.JAR_MANIFEST).outputFile(mfJar.getAbsolutePath())
+                );
+
+        GradleBuild.generateGradleBuildFiles(gradeDir, c);
+
+        //Check for gradlew and gradlew.bat
+
+        //Check for build.gradle.kts
+        File buildGradle = new File(gradeDir, "build.gradle.kts");
+        assertTrue(buildGradle.exists());
+        String buildGradleStr = FileUtils.readFileToString(buildGradle, StandardCharsets.UTF_8);
+
+        //Check that it includes the appropriate section
+        assertTrue(buildGradleStr, buildGradleStr.contains("manifest"));
+        assertTrue(buildGradleStr, buildGradleStr.contains("Class-Path"));
+
+        //Actually run the build
+        //TODO this might not be doable in a unit test (unless all modules have been installed to local maven repo first)
+        GradleBuild.runGradleBuild(gradeDir, c);
+
+        assertTrue(mfJar.exists());
+        File dest = new File(dir, "mf.txt");
+        ArchiveUtils.zipExtractSingleFile(mfJar, dest, "META-INF/MANIFEST.MF");
+        String mfContent = FileUtils.readFileToString(dest, StandardCharsets.UTF_8);
+        mfContent = mfContent.replace("\n ", "");
+        assertTrue(mfContent.contains("Class-Path: "));
+        assertTrue(mfContent.contains(".jar"));
+        assertTrue(mfContent.contains("konduit-serving-pipeline"));
+        assertTrue(mfContent.contains("nd4j-native-1.0.0"));
+        assertTrue(mfContent.contains("deeplearning4j-core"));
     }
 }


### PR DESCRIPTION
See ADR here for description and motivation.

Also adds the implementation - creation of an otherwise empty JAR with classpath defined in manifest (META-INF/MANIFEST.MF).