### PR TITLE
Handle Bounding Box in copy_from

### DIFF
--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Data.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Data.java
@@ -339,6 +339,9 @@ public interface Data {
             case DATA:
                 put(key, from.getData(key));
                 return;
+            case BOUNDING_BOX:
+                put(key, from.getBoundingBox(key));
+                return;
             case LIST:
                 ValueType vtList = from.listType(key);
                 List<?> l = from.getList(key, vtList);

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/JData.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/JData.java
@@ -488,6 +488,11 @@ public class JData implements Data {
             instance.put(key, data);
             return this;
         }
+        
+        public DataBuilder add(String key, BoundingBox data){
+            instance.put(key, data);
+            return this;
+        }
 
         public DataBuilder addListString(String key, List<String> data) {
             instance.putListString(key, data);
@@ -521,6 +526,11 @@ public class JData implements Data {
 
         public DataBuilder addListNDArray(String key, List<NDArray> data) {
             instance.putListNDArray(key, data);
+            return this;
+        }
+
+        public DataBuilder addListBoundingBox(String key, List<BoundingBox> data) {
+            instance.putListBoundingBox(key, data);
             return this;
         }
 


### PR DESCRIPTION
It looks like the bounding box case was missed for the single bounding box copy. I assume it is supposed to be handled because the list case does handle it.

Found another case where BoundingBox wasn't handled (JData.DataBuilder) and added it there too.