### PR TITLE
Add DrawPointsStep and DrawHeatmapStep

### DIFF
--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStep.java
@@ -1,0 +1,86 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.point.draw;
+
+import ai.konduit.serving.annotation.json.JsonName;
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Draw 2D points<br>
+ * Configuration:<br>
+ * <ul>
+ *     <li><b>classColors</b>: Optional: A list of colors to use for each class. Must be in one of the following formats: hex/HTML - "#788E87",
+ *             RGB - "rgb(128,0,255)", or one of 16 HTML color name such as \"green\" (https://en.wikipedia.org/wiki/Web_colors#HTML_color_names).
+ *             If no colors are specified, or not enough colors are specified, random colors are used instead (note consistent between runs).
+ *             Colors are mapped to named classes in alphabetical order, i.e. first color to class A, second color to class B, etc...</li>
+ *     <li><b>points</b>: Names of the points to be drawn. Accepts both single points and lists of points.
+ *     <li><b>image</b>: Optional. Name of the image to use as size reference</li>
+ *     <li><b>width</b>: Must be provided when <b>image</b> isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)</li>
+ *     <li><b>height</b>: Must be provided when <b>image</b> isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)</li>
+ *     <li><b>outputName</b>: Name of the output image</li>
+ * </ul>
+ *
+ * @author Paul Dubs
+ */
+@Builder
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+@JsonName("DRAW_POINTS")
+@Schema(description = "A pipeline step that configures how to draw 2D points, optionally on an image.")
+public class DrawPointsStep implements PipelineStep {
+    public static final String DEFAULT_OUTPUT_NAME = "image";
+
+    @Schema(description = "This is an optional field which specifies the mapping of colors to use for each class. " +
+            "The color can be a hex/HTML string like" +
+            "\"#788E87\", an RGB value like RGB - \"rgb(128,0,255)\" or  it can be from a set of predefined HTML color names: " +
+            "[white, silver, gray, black, red, maroon, yellow, olive, lime, green, aqua, teal, blue, navy, fuchsia, purple]")
+    private Map<String, String> classColors;
+
+    @Schema(description = "Names of the points to be drawn. Accepts both single points and lists of points.")
+    @Singular
+    private List<String> points;
+
+    @Schema(description = "Point radius on drawn image. ")
+    private Integer radius;
+
+    @Schema(description = "An optional field, specifying the name of the image to use as size reference")
+    private String image;
+
+    @Schema(description = "Must be provided when \"image\" isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)")
+    private Integer width;
+
+    @Schema(description = "Must be provided when \"image\" isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)")
+    private Integer height;
+
+
+
+    @Schema(description = "Name of the output image",
+            defaultValue = DEFAULT_OUTPUT_NAME)
+    private String outputName;
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStep.java
@@ -39,6 +39,7 @@ import java.util.Map;
  *             If no colors are specified, or not enough colors are specified, random colors are used instead (note consistent between runs).
  *             Colors are mapped to named classes in alphabetical order, i.e. first color to class A, second color to class B, etc...</li>
  *     <li><b>points</b>: Names of the points to be drawn. Accepts both single points and lists of points.
+ *     <li><b>radius</b>: Point radius on drawn image. </li>
  *     <li><b>image</b>: Optional. Name of the image to use as size reference</li>
  *     <li><b>width</b>: Must be provided when <b>image</b> isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)</li>
  *     <li><b>height</b>: Must be provided when <b>image</b> isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)</li>

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStep.java
@@ -21,10 +21,7 @@ package ai.konduit.serving.data.image.step.point.draw;
 import ai.konduit.serving.annotation.json.JsonName;
 import ai.konduit.serving.pipeline.api.step.PipelineStep;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Singular;
+import lombok.*;
 import lombok.experimental.Accessors;
 
 import java.util.List;
@@ -48,12 +45,12 @@ import java.util.Map;
  *
  * @author Paul Dubs
  */
-@Builder
 @Data
 @Accessors(fluent = true)
 @AllArgsConstructor
+@NoArgsConstructor
 @JsonName("DRAW_POINTS")
-@Schema(description = "A pipeline step that configures how to draw 2D points, optionally on an image.")
+@Schema(description = "A pipeline step that configures how to draw 2D points.")
 public class DrawPointsStep implements PipelineStep {
     public static final String DEFAULT_OUTPUT_NAME = "image";
 
@@ -63,11 +60,11 @@ public class DrawPointsStep implements PipelineStep {
             "[white, silver, gray, black, red, maroon, yellow, olive, lime, green, aqua, teal, blue, navy, fuchsia, purple]")
     private Map<String, String> classColors;
 
-    @Schema(description = "Names of the points to be drawn. Accepts both single points and lists of points.")
+    @Schema(description = "Name of the input data fields containing the points to be drawn. Accepts both single points and lists of points. Accepts both relative and absolute addressed points.")
     @Singular
     private List<String> points;
 
-    @Schema(description = "Point radius on drawn image. ")
+    @Schema(description = "Optional. Point radius on drawn image. Default = 5px")
     private Integer radius;
 
     @Schema(description = "An optional field, specifying the name of the image to use as size reference")

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
@@ -57,9 +57,6 @@ public class DrawPointsStepRunner implements PipelineStepRunner {
 
     @Override
     public Data exec(Context ctx, Data data) {
-        // TODO: Ask Alex about consuming and non consuming Steps. It seems to me that unused inputs should
-        //       always go through unchanged
-        // TODO: Ask Alex about lombok val usage. What style is preferred?
         Data out = Data.empty();
         for(String key : data.keys()){
             out.copyFrom(key, data);

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
@@ -62,6 +62,10 @@ public class DrawPointsStepRunner implements PipelineStepRunner {
             out.copyFrom(key, data);
         }
 
+        if(step.points() == null || step.points().size() == 0){
+            throw new IllegalArgumentException("No point input data fields defined. Nothing to draw.");
+        }
+
         // collect points
         List<Point> points = new LinkedList<>();
         for (String pointName : step.points()) {

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
@@ -1,0 +1,155 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.point.draw;
+
+import ai.konduit.serving.annotation.runner.CanRun;
+import ai.konduit.serving.data.image.util.ColorUtil;
+import ai.konduit.serving.pipeline.api.context.Context;
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.Image;
+import ai.konduit.serving.pipeline.api.data.Point;
+import ai.konduit.serving.pipeline.api.data.ValueType;
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
+import lombok.NonNull;
+import org.bytedeco.opencv.global.opencv_imgproc;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Scalar;
+import org.opencv.core.CvType;
+
+import java.util.*;
+
+@CanRun(DrawPointsStep.class)
+public class DrawPointsStepRunner implements PipelineStepRunner {
+
+    protected final DrawPointsStep step;
+    protected Map<String, Scalar> labelMap;
+
+    public DrawPointsStepRunner(@NonNull DrawPointsStep step) {
+        this.step = step;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public PipelineStep getPipelineStep() {
+        return step;
+    }
+
+    @Override
+    public Data exec(Context ctx, Data data) {
+        // TODO: Ask Alex about consuming and non consuming Steps. It seems to me that unused inputs should
+        //       always go through unchanged
+        // TODO: Ask Alex about lombok val usage. What style is preferred?
+        Data out = Data.empty();
+        for(String key : data.keys()){
+            out.copyFrom(key, data);
+        }
+
+        // collect points and how many classes there are
+        List<Point> points = new LinkedList<>();
+        for (String pointName : step.points()) {
+            ValueType type = data.type(pointName);
+            if(type == ValueType.POINT){
+                Point point = data.getPoint(pointName);
+                if(point.dimensions() != 2){
+                    throw new IllegalArgumentException("Point in input "+pointName+" has "+point.dimensions()+" dimensions, but only 2 dimensional points are supported for drawing!");
+                }
+                points.add(point);
+            }else if(type == ValueType.LIST){
+                List<Point> pointList = data.getListPoint(pointName);
+                for (Point point : pointList) {
+                    if(point.dimensions() != 2){
+                        throw new IllegalArgumentException("Point in input "+pointName+" has "+point.dimensions()+" dimensions, but only 2 dimensional points are supported for drawing!");
+                    }
+                }
+                points.addAll(pointList);
+            }else {
+                throw new IllegalArgumentException("The configured input "+pointName+" is neither a point nor a list of points!");
+            }
+        }
+        // Initialize colors first if they weren't initialized at all
+        if(labelMap == null) {
+            Map<String, String> classColors = step.classColors();
+            initColors(classColors, classColors.size());
+        }
+
+        // get reference size
+        int width;
+        int height;
+        if(step.image() != null){
+            ValueType type = data.type(step.image());
+            if(type == ValueType.IMAGE){
+                Image image = data.getImage(step.image());
+                width = image.width();
+                height = image.height();
+            }else{
+                throw new IllegalArgumentException("The configured reference image input "+step.image()+" is not an Image!");
+            }
+        }else if(step.width() != null && step.height() != null){
+            width = step.width();
+            height = step.height();
+        }else{
+            throw new IllegalArgumentException("You have to provide either a reference image or width AND height!");
+        }
+
+        // turn points with relative addressing to absolute addressing
+        List<Point> absPoints = new ArrayList<>(points.size());
+        for (Point point : points) {
+            absPoints.add(point.toAbsolute(width, height));
+        }
+
+        // create empty image
+        Mat image = new Mat();
+        image.put(Mat.zeros(height, width, CvType.CV_8UC3));
+
+        // draw points on image with color according to labels
+        int radius = step.radius() == null ? 5 : step.radius();
+        for (Point point : absPoints) {
+            Scalar color = labelMap.get(point.label());
+            if(color == null){
+                throw new IllegalArgumentException("No color provided for label "+point.label());
+            }
+
+            opencv_imgproc.circle(
+                    image,
+                    new org.bytedeco.opencv.opencv_core.Point((int)point.x(), (int)point.y()),
+                    radius,
+                    color,
+                    opencv_imgproc.FILLED,
+                    opencv_imgproc.LINE_AA,
+                    0
+            );
+        }
+
+        // return image
+        out.put(step.outputName() == null ? DrawPointsStep.DEFAULT_OUTPUT_NAME : step.outputName(), Image.create(image));
+        return out;
+    }
+
+    private void initColors(Map<String, String> classColors, int max) {
+        labelMap = new HashMap<>(classColors.size());
+        for (Map.Entry<String, String> entry : classColors.entrySet()) {
+            labelMap.put(entry.getKey(), ColorUtil.stringToColor(entry.getValue()));
+        }
+    }
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunner.java
@@ -65,7 +65,7 @@ public class DrawPointsStepRunner implements PipelineStepRunner {
             out.copyFrom(key, data);
         }
 
-        // collect points and how many classes there are
+        // collect points
         List<Point> points = new LinkedList<>();
         for (String pointName : step.points()) {
             ValueType type = data.type(pointName);

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunnerFactory.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/draw/DrawPointsStepRunnerFactory.java
@@ -1,0 +1,37 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.point.draw;
+
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory;
+import org.nd4j.common.base.Preconditions;
+
+public class DrawPointsStepRunnerFactory implements PipelineStepRunnerFactory {
+    @Override
+    public boolean canRun(PipelineStep pipelineStep) {
+        return pipelineStep instanceof DrawPointsStep;
+    }
+
+    @Override
+    public PipelineStepRunner create(PipelineStep pipelineStep) {
+        Preconditions.checkState(canRun(pipelineStep), "Unable to run step: %s", pipelineStep);
+        return new DrawPointsStepRunner((DrawPointsStep)pipelineStep);
+    }
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStep.java
@@ -54,7 +54,7 @@ import java.util.List;
 public class DrawHeatmapStep implements PipelineStep {
     public static final String DEFAULT_OUTPUT_NAME = "image";
 
-    @Schema(description = "Name of the input data fields containing the points used for the heatmap. Accepts both single points and lists of points.")
+    @Schema(description = "Name of the input data fields containing the points used for the heatmap. Accepts both single points and lists of points. Accepts both relative and absolute addressed points.")
     @Singular
     private List<String> points;
 

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStep.java
@@ -22,8 +22,8 @@ import ai.konduit.serving.annotation.json.JsonName;
 import ai.konduit.serving.pipeline.api.step.PipelineStep;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.Singular;
 import lombok.experimental.Accessors;
 
@@ -45,16 +45,16 @@ import java.util.List;
  *
  * @author Paul Dubs
  */
-@Builder
 @Data
 @Accessors(fluent = true)
 @AllArgsConstructor
+@NoArgsConstructor
 @JsonName("DRAW_HEATMAP")
-@Schema(description = "A pipeline step that configures how to draw 2D points, optionally on an image.")
+@Schema(description = "A pipeline step that configures how to draw a 2D pipeline.")
 public class DrawHeatmapStep implements PipelineStep {
     public static final String DEFAULT_OUTPUT_NAME = "image";
 
-    @Schema(description = "Names of the points to be used for the heatmap. Accepts both single points and lists of points.")
+    @Schema(description = "Name of the input data fields containing the points used for the heatmap. Accepts both single points and lists of points.")
     @Singular
     private List<String> points;
 

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStep.java
@@ -1,0 +1,79 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.point.heatmap;
+
+import ai.konduit.serving.annotation.json.JsonName;
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+/**
+ * Draw a heatmap using 2D points.<br>
+ * Heat will accumulate over the lifecycle of this step.<br>
+ * Configuration:<br>
+ * <ul>
+ *     <li><b>points</b>: Names of the points to be used for the heatmap. Accepts both single points and lists of points.
+ *     <li><b>radius</b>: Size of area influenced by a point.</li>
+ *     <li><b>fadingFactor</b>: Optional. Value between 0 and 1. 0: No Fade, 1: Instant fade</li>
+ *     <li><b>image</b>: Optional. Name of the image to use as size reference</li>
+ *     <li><b>width</b>: Must be provided when <b>image</b> isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)</li>
+ *     <li><b>height</b>: Must be provided when <b>image</b> isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)</li>
+ *     <li><b>outputName</b>: Name of the output image</li>
+ * </ul>
+ *
+ * @author Paul Dubs
+ */
+@Builder
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+@JsonName("DRAW_HEATMAP")
+@Schema(description = "A pipeline step that configures how to draw 2D points, optionally on an image.")
+public class DrawHeatmapStep implements PipelineStep {
+    public static final String DEFAULT_OUTPUT_NAME = "image";
+
+    @Schema(description = "Names of the points to be used for the heatmap. Accepts both single points and lists of points.")
+    @Singular
+    private List<String> points;
+
+    @Schema(description = "Size of area influenced by a point")
+    private Integer radius;
+
+    @Schema(description = "Fading factor. 0: no fade, 1: instant fade")
+    private Double fadingFactor;
+
+    @Schema(description = "An optional field, specifying the name of the image to use as size reference")
+    private String image;
+
+    @Schema(description = "Must be provided when \"image\" isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)")
+    private Integer width;
+
+    @Schema(description = "Must be provided when \"image\" isn't set. Used to resolve position of points with relative addressing (dimensions between 0 and 1)")
+    private Integer height;
+
+    @Schema(description = "Name of the output image",
+            defaultValue = DEFAULT_OUTPUT_NAME)
+    private String outputName;
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStepRunner.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStepRunner.java
@@ -1,0 +1,154 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.point.heatmap;
+
+import ai.konduit.serving.annotation.runner.CanRun;
+import ai.konduit.serving.pipeline.api.context.Context;
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.Image;
+import ai.konduit.serving.pipeline.api.data.Point;
+import ai.konduit.serving.pipeline.api.data.ValueType;
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.bytedeco.javacpp.DoublePointer;
+import org.bytedeco.javacpp.indexer.DoubleIndexer;
+import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.global.opencv_imgproc;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Size;
+import org.opencv.core.CvType;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Slf4j
+@CanRun(DrawHeatmapStep.class)
+public class DrawHeatmapStepRunner implements PipelineStepRunner {
+
+    protected final DrawHeatmapStep step;
+    protected Mat prev;
+
+    public DrawHeatmapStepRunner(@NonNull DrawHeatmapStep step) {
+        this.step = step;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public PipelineStep getPipelineStep() {
+        return step;
+    }
+
+    @Override
+    public Data exec(Context ctx, Data data) {
+        Data out = Data.empty();
+        for(String key : data.keys()){
+            out.copyFrom(key, data);
+        }
+
+        // get reference size
+        int width;
+        int height;
+        if(step.image() != null){
+            ValueType type = data.type(step.image());
+            if(type == ValueType.IMAGE){
+                Image image = data.getImage(step.image());
+                width = image.width();
+                height = image.height();
+            }else{
+                throw new IllegalArgumentException("The configured reference image input "+step.image()+" is not an Image!");
+            }
+        }else if(step.width() != null && step.height() != null){
+            width = step.width();
+            height = step.height();
+        }else{
+            throw new IllegalArgumentException("You have to provide either a reference image or width AND height!");
+        }
+
+        if(prev == null){
+            prev = new Mat();
+            prev.put(Mat.zeros(height, width, CvType.CV_64FC1));
+        }
+
+        // collect points
+        List<Point> points = new LinkedList<>();
+        for (String pointName : step.points()) {
+            ValueType type = data.type(pointName);
+            if(type == ValueType.POINT){
+                Point point = data.getPoint(pointName);
+                if(point.dimensions() != 2){
+                    throw new IllegalArgumentException("Point in input "+pointName+" has "+point.dimensions()+" dimensions, but only 2 dimensional points are supported for drawing!");
+                }
+                points.add(point.toAbsolute(width, height));
+            }else if(type == ValueType.LIST){
+                List<Point> pointList = data.getListPoint(pointName);
+                for (Point point : pointList) {
+                    if(point.dimensions() != 2){
+                        throw new IllegalArgumentException("Point in input "+pointName+" has "+point.dimensions()+" dimensions, but only 2 dimensional points are supported for drawing!");
+                    }
+                    points.add(point.toAbsolute(width, height));
+                }
+            }else {
+                throw new IllegalArgumentException("The configured input "+pointName+" is neither a point nor a list of points!");
+            }
+        }
+
+        Mat mat = new Mat();
+        mat.put(Mat.zeros(height, width, CvType.CV_64FC1));
+        DoubleIndexer idx = mat.createIndexer();
+        for (Point point : points) {
+            int row = (int) point.y();
+            int col = (int) point.x();
+            if(row > height || col > width){
+                log.warn("{} is out of bounds ({}, {})", point, width, height);
+            }else {
+                idx.put(row, col, idx.get(row, col) + 255);
+            }
+        }
+
+        int radius = step.radius() == null ? 15 : step.radius();
+        int kSize = radius * 8 + 1;
+
+        Size kernelSize = new Size(kSize, kSize);
+        opencv_imgproc.GaussianBlur(mat, mat, kernelSize, radius, radius, opencv_core.BORDER_ISOLATED);
+
+        mat.put(opencv_core.add(opencv_core.multiply(prev, step.fadingFactor() == null ? 0.9 : step.fadingFactor()), mat));
+        prev.close();
+        prev = mat;
+
+        DoublePointer maxVal = new DoublePointer(1);
+        opencv_core.minMaxLoc(mat, null, maxVal, null, null, null);
+
+        Mat scaledOut = new Mat();
+        mat.convertTo(scaledOut, CvType.CV_8UC1, 255/maxVal.get(), 0);
+        maxVal.close();
+
+        Mat image = new Mat();
+        opencv_imgproc.applyColorMap(scaledOut, image, opencv_imgproc.COLORMAP_TURBO);
+
+        // return image
+        out.put(step.outputName() == null ? DrawHeatmapStep.DEFAULT_OUTPUT_NAME : step.outputName(), Image.create(image));
+        return out;
+    }
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStepRunnerFactory.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/step/point/heatmap/DrawHeatmapStepRunnerFactory.java
@@ -1,0 +1,37 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image.step.point.heatmap;
+
+import ai.konduit.serving.pipeline.api.step.PipelineStep;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunner;
+import ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory;
+import org.nd4j.common.base.Preconditions;
+
+public class DrawHeatmapStepRunnerFactory implements PipelineStepRunnerFactory {
+    @Override
+    public boolean canRun(PipelineStep pipelineStep) {
+        return pipelineStep instanceof DrawHeatmapStep;
+    }
+
+    @Override
+    public PipelineStepRunner create(PipelineStep pipelineStep) {
+        Preconditions.checkState(canRun(pipelineStep), "Unable to run step: %s", pipelineStep);
+        return new DrawHeatmapStepRunner((DrawHeatmapStep)pipelineStep);
+    }
+}

--- a/konduit-serving-data/konduit-serving-image/src/main/resources/META-INF/services/ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory
+++ b/konduit-serving-data/konduit-serving-image/src/main/resources/META-INF/services/ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory
@@ -23,5 +23,6 @@ ai.konduit.serving.data.image.step.segmentation.index.DrawSegmentationStepRunner
 ai.konduit.serving.data.image.step.grid.crop.CropGridStepRunnerFactory
 ai.konduit.serving.data.image.step.face.DrawFaceKeyPointsStepRunnerFactory
 ai.konduit.serving.data.image.step.point.perspective.convert.PerspectiveTransformStepRunnerFactory
+ai.konduit.serving.data.image.step.point.draw.DrawPointsStepRunnerFactory
 ai.konduit.serving.data.image.step.resize.ImageResizeFactory
 ai.konduit.serving.data.image.step.crop.ImageCropFactory

--- a/konduit-serving-data/konduit-serving-image/src/main/resources/META-INF/services/ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory
+++ b/konduit-serving-data/konduit-serving-image/src/main/resources/META-INF/services/ai.konduit.serving.pipeline.api.step.PipelineStepRunnerFactory
@@ -24,5 +24,6 @@ ai.konduit.serving.data.image.step.grid.crop.CropGridStepRunnerFactory
 ai.konduit.serving.data.image.step.face.DrawFaceKeyPointsStepRunnerFactory
 ai.konduit.serving.data.image.step.point.perspective.convert.PerspectiveTransformStepRunnerFactory
 ai.konduit.serving.data.image.step.point.draw.DrawPointsStepRunnerFactory
+ai.konduit.serving.data.image.step.point.heatmap.DrawHeatmapStepRunnerFactory
 ai.konduit.serving.data.image.step.resize.ImageResizeFactory
 ai.konduit.serving.data.image.step.crop.ImageCropFactory

--- a/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawHeatmapStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawHeatmapStep.java
@@ -30,6 +30,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public class TestDrawHeatmapStep {
 
@@ -37,12 +38,11 @@ public class TestDrawHeatmapStep {
     @Test
     public void testSingleStep() throws Exception {
         Pipeline p = SequencePipeline.builder()
-                .add(DrawHeatmapStep.builder()
-                        .point("points")
+                .add(new DrawHeatmapStep()
+                        .points(Collections.singletonList("points"))
                         .width(100)
                         .height(200)
-                        .outputName("image")
-                        .build())
+                        .outputName("image"))
                 .add(new ShowImagePipelineStep())
                 .build();
 
@@ -65,13 +65,12 @@ public class TestDrawHeatmapStep {
     @Test
     public void testMultiStep() throws Exception {
         Pipeline p = SequencePipeline.builder()
-                .add(DrawHeatmapStep.builder()
-                        .point("points")
+                .add(new DrawHeatmapStep()
+                        .points(Collections.singletonList("points"))
                         .width(100)
                         .height(200)
                         .outputName("image")
-                        .radius(10)
-                        .build())
+                        .radius(10))
                 .add(new ShowImagePipelineStep())
                 .build();
 

--- a/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawHeatmapStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawHeatmapStep.java
@@ -1,0 +1,112 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image;
+
+import ai.konduit.serving.data.image.step.point.heatmap.DrawHeatmapStep;
+import ai.konduit.serving.data.image.step.show.ShowImagePipelineStep;
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.Point;
+import ai.konduit.serving.pipeline.api.data.ValueType;
+import ai.konduit.serving.pipeline.api.pipeline.Pipeline;
+import ai.konduit.serving.pipeline.api.pipeline.PipelineExecutor;
+import ai.konduit.serving.pipeline.impl.pipeline.SequencePipeline;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class TestDrawHeatmapStep {
+
+    @Ignore
+    @Test
+    public void testSingleStep() throws Exception {
+        Pipeline p = SequencePipeline.builder()
+                .add(DrawHeatmapStep.builder()
+                        .point("points")
+                        .width(100)
+                        .height(200)
+                        .outputName("image")
+                        .build())
+                .add(new ShowImagePipelineStep())
+                .build();
+
+        Data data = Data.empty();
+        data.putListPoint("points",
+                Arrays.asList(
+                        Point.create(2, 2, "bar", 0.1),
+                        Point.create(0.1, 0.1, "foo", 0.2),
+                        Point.create(0.5, 0.8, "bar", 0.3),
+                        Point.create(30, 59, "foo", 0.4)
+                )
+        );
+
+        Data out = p.executor().exec(data);
+
+        Thread.sleep(Long.MAX_VALUE);
+    }
+
+    @Ignore
+    @Test
+    public void testMultiStep() throws Exception {
+        Pipeline p = SequencePipeline.builder()
+                .add(DrawHeatmapStep.builder()
+                        .point("points")
+                        .width(100)
+                        .height(200)
+                        .outputName("image")
+                        .radius(10)
+                        .build())
+                .add(new ShowImagePipelineStep())
+                .build();
+
+        Data data = Data.empty();
+        data.putListPoint("points",
+                Arrays.asList(
+                        Point.create(2, 2, "bar", 0.1),
+                        Point.create(0.1, 0.1, "foo", 0.2),
+                        Point.create(0.5, 0.8, "bar", 0.3),
+                        Point.create(30, 59, "foo", 0.4)
+                )
+        );
+
+        PipelineExecutor executor = p.executor();
+        Data out = executor.exec(data);
+
+        executor.exec(Data.singletonList("points",
+                Arrays.asList(
+                        Point.create(8, 12, "bar", 0.1),
+                        Point.create(0.2, 0.2, "foo", 0.2),
+                        Point.create(0.6, 0.8, "bar", 0.3)
+                ), ValueType.POINT));
+
+        executor.exec(Data.singletonList("points",
+                Arrays.asList(
+                        Point.create(0.3, 0.3, "foo", 0.2),
+                        Point.create(0.7, 0.8, "bar", 0.3)
+                ), ValueType.POINT));
+
+        executor.exec(Data.singletonList("points",
+                Arrays.asList(
+                        Point.create(0.9, 0.8, "bar", 0.3)
+                ), ValueType.POINT));
+
+        Thread.sleep(Long.MAX_VALUE);
+    }
+
+}

--- a/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawPointsStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawPointsStep.java
@@ -28,6 +28,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
 public class TestDrawPointsStep {
@@ -40,13 +41,12 @@ public class TestDrawPointsStep {
         colorMap.put("bar", "green");
 
         Pipeline p = SequencePipeline.builder()
-                .add(DrawPointsStep.builder()
+                .add(new DrawPointsStep()
                         .classColors(colorMap)
-                        .point("points")
+                        .points(Collections.singletonList("points"))
                         .width(100)
                         .height(200)
-                        .outputName("image")
-                        .build())
+                        .outputName("image"))
                 .add(new ShowImagePipelineStep())
                 .build();
 

--- a/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawPointsStep.java
+++ b/konduit-serving-data/konduit-serving-image/src/test/java/ai/konduit/serving/data/image/TestDrawPointsStep.java
@@ -1,0 +1,67 @@
+/*
+ *  ******************************************************************************
+ *  * Copyright (c) 2020 Konduit K.K.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package ai.konduit.serving.data.image;
+
+import ai.konduit.serving.data.image.step.point.draw.DrawPointsStep;
+import ai.konduit.serving.data.image.step.show.ShowImagePipelineStep;
+import ai.konduit.serving.pipeline.api.data.Data;
+import ai.konduit.serving.pipeline.api.data.Point;
+import ai.konduit.serving.pipeline.api.pipeline.Pipeline;
+import ai.konduit.serving.pipeline.impl.pipeline.SequencePipeline;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class TestDrawPointsStep {
+
+    @Ignore
+    @Test
+    public void testNoReferenceImage() throws Exception {
+        HashMap<String, String> colorMap = new HashMap<>();
+        colorMap.put("foo", "red");
+        colorMap.put("bar", "green");
+
+        Pipeline p = SequencePipeline.builder()
+                .add(DrawPointsStep.builder()
+                        .classColors(colorMap)
+                        .point("points")
+                        .width(100)
+                        .height(200)
+                        .outputName("image")
+                        .build())
+                .add(new ShowImagePipelineStep())
+                .build();
+
+        Data data = Data.empty();
+        data.putListPoint("points",
+                Arrays.asList(
+                        Point.create(2, 2, "bar", 0.1),
+                        Point.create(0.1, 0.1, "foo", 0.2),
+                        Point.create(0.5, 0.8, "bar", 0.3),
+                        Point.create(30, 59, "foo", 0.4)
+                )
+        );
+
+        Data out = p.executor().exec(data);
+
+        Thread.sleep(Long.MAX_VALUE);
+    }
+}

--- a/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestTensorFlowStep.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/test/java/ai/konduit/serving/models/tensorflow/TestTensorFlowStep.java
@@ -878,18 +878,16 @@ public class TestTensorFlowStep {
         //Merge camera image with bounding boxes
         GraphStep merged = camera.mergeWith("img_bbox", ssdProc);
 
-        GraphStep drawer = merged.then("toPoints", BoundingBoxToPointStep.builder()
+        GraphStep drawer = merged.then("toPoints", new BoundingBoxToPointStep()
                 .bboxName("img_bbox")
                 .method(BoundingBoxToPointStep.ConversionMethod.CENTER)
                 .keepOtherFields(true)
                 .outputName("img_points")
-                .build()
-        ).then("drawer", DrawHeatmapStep.builder()
+        ).then("drawer", new DrawHeatmapStep()
                 .image("image")
-                .point("img_points")
+                .points(Arrays.asList("img_points"))
                 .fadingFactor(1.0)
-                .radius(30)
-                .build());
+                .radius(30));
 
 
         //Show image in Java frame

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Point.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/api/data/Point.java
@@ -163,4 +163,21 @@ public interface Point {
                         (p1.probability() != null && Math.abs(p1.probability() - p2.probability()) < probEps));
     }
 
+
+    /**
+     * Turn relative defined coordinates into absolute coordinates
+     */
+    default Point toAbsolute(double... absoluteSizes){
+        // if the first point is absolute (not between 0 and 1), all others should be too
+        if(!(0.0 < x() && x() < 1.0)) { return this; }
+
+        double[] coords = new double[dimensions()];
+        if(coords.length != absoluteSizes.length){
+            throw new IllegalArgumentException("An absolute size has to be defined for each dimension of the point!");
+        }
+        for (int i = 0; i < coords.length; i++) {
+            coords[i] = absoluteSizes[i] * get(i);
+        }
+        return Point.create(coords, label(), probability());
+    }
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/bbox/point/BoundingBoxToPointStep.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/bbox/point/BoundingBoxToPointStep.java
@@ -21,7 +21,6 @@ package ai.konduit.serving.pipeline.impl.step.bbox.point;
 import ai.konduit.serving.annotation.json.JsonName;
 import ai.konduit.serving.pipeline.api.step.PipelineStep;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
@@ -35,7 +34,6 @@ import lombok.experimental.Accessors;
  * the output will be a single value; if the input is a list, the output will be a list.<br>
  */
 @Data
-@Builder
 @Accessors(fluent = true)
 @AllArgsConstructor
 @NoArgsConstructor

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/bbox/point/BoundingBoxToPointStep.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/step/bbox/point/BoundingBoxToPointStep.java
@@ -35,6 +35,7 @@ import lombok.experimental.Accessors;
  * the output will be a single value; if the input is a list, the output will be a list.<br>
  */
 @Data
+@Builder
 @Accessors(fluent = true)
 @AllArgsConstructor
 @NoArgsConstructor


### PR DESCRIPTION
DrawPointsStep takes a point or a list of points and a mapping for their labels to colors, and draws those on a black background. 

DrawHeatmapStep takes a point or a list of points and draws a heatmap. It collects point positions over time, so depending on the fading factor, old "heat" is retained.

Both steps pass through all data that is given to them - I'm not sure if that is something that they should do, as not all steps actually do that. On some it is a configuration option, others just don't do it.

And another question on style: As we have lombok in the project, we can use `val`, so far I've tried to stay as close to plain java as possible. What is the preferred style there?

