### PR TITLE
Ensure compilation on java 11 by casting buffers, add test scope for …

### DIFF
--- a/konduit-serving-core/pom.xml
+++ b/konduit-serving-core/pom.xml
@@ -307,6 +307,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/format/JavaCVImageConverters.java
+++ b/konduit-serving-data/konduit-serving-image/src/main/java/ai/konduit/serving/data/image/format/JavaCVImageConverters.java
@@ -34,6 +34,7 @@ import org.bytedeco.opencv.opencv_core.CvArr;
 import org.bytedeco.opencv.opencv_core.IplImage;
 import org.bytedeco.opencv.opencv_core.Mat;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static org.bytedeco.opencv.global.opencv_imgproc.*;
@@ -88,7 +89,8 @@ public class JavaCVImageConverters {
         protected <T> T doConversion(Image from, Class<T> to) {
             BaseImageFile p = (BaseImageFile) from.get();
             ByteBuffer fileBytes = p.getFileBytes();
-            fileBytes.position(0);
+            Buffer bufferCast = (Buffer) fileBytes;
+            bufferCast.position(0);
 
             Mat m = new Mat(new BytePointer(fileBytes), false);
             Mat out = org.bytedeco.opencv.global.opencv_imgcodecs.imdecode(m, opencv_imgcodecs.IMREAD_UNCHANGED);

--- a/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/format/TensorFlowConverters.java
+++ b/konduit-serving-models/konduit-serving-tensorflow/src/main/java/ai/konduit/serving/models/tensorflow/format/TensorFlowConverters.java
@@ -29,6 +29,7 @@ import org.nd4j.common.base.Preconditions;
 import org.nd4j.common.util.ArrayUtil;
 import org.tensorflow.Tensor;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -67,7 +68,8 @@ public class TensorFlowConverters {
         public Tensor<?> convert(SerializedNDArray from){
             long[] shape = from.getShape();
             Class<?> tfType = TensorFlowUtil.toTFType(from.getType());
-            from.getBuffer().rewind();
+            Buffer buffer = (Buffer) from.getBuffer();
+            buffer.rewind();
             Tensor<?> t = Tensor.create(tfType, shape, from.getBuffer());
             return t;
         }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/ndarray/SerializedNDArray.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/data/ndarray/SerializedNDArray.java
@@ -22,6 +22,7 @@ import ai.konduit.serving.pipeline.api.data.NDArrayType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -61,4 +62,13 @@ public class SerializedNDArray {
 
         return true;
     }
+
+    public static ByteBuffer resetSerializedNDArrayBuffer(SerializedNDArray sa) {
+        Buffer buffer = sa.getBuffer();
+        buffer.rewind();
+        ByteBuffer byteBuffer = sa.getBuffer().asReadOnlyBuffer();
+        byteBuffer.position(0);
+        return  byteBuffer;
+    }
+
 }

--- a/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/format/JavaNDArrayConverters.java
+++ b/konduit-serving-pipeline/src/main/java/ai/konduit/serving/pipeline/impl/format/JavaNDArrayConverters.java
@@ -854,7 +854,7 @@ public class JavaNDArrayConverters {
         }
 
         private void put(long[][][][][] toAdd, LongBuffer lb){
-            for(int i=0; i<toAdd.length; i++ ){
+            for(int i = 0; i < toAdd.length; i++) {
                 put(toAdd[i], lb);
             }
         }
@@ -913,7 +913,8 @@ public class JavaNDArrayConverters {
         @Override
         protected  <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             FloatBuffer fb = sa.getBuffer().asFloatBuffer();
             float[] out = new float[fb.remaining()];
             fb.get(out);
@@ -931,7 +932,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             FloatBuffer fb = sa.getBuffer().asFloatBuffer();
             fb.position(0);
             long[] shape = sa.getShape();
@@ -953,7 +955,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = (Buffer) sa.getBuffer();
+            buffer.rewind();
             FloatBuffer fb = sa.getBuffer().asFloatBuffer();
             fb.position(0);
             long[] shape = sa.getShape();
@@ -977,7 +980,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer  = (Buffer) sa.getBuffer();
+            buffer.rewind();
             FloatBuffer fb = sa.getBuffer().asFloatBuffer();
             fb.position(0);
             long[] shape = sa.getShape();
@@ -1003,7 +1007,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = sa.getBuffer();
+            buffer.rewind();
             FloatBuffer fb = sa.getBuffer().asFloatBuffer();
             fb.position(0);
             long[] shape = sa.getShape();
@@ -1031,7 +1036,8 @@ public class JavaNDArrayConverters {
         @Override
         protected  <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = sa.getBuffer();
+            buffer.rewind();
             DoubleBuffer db = sa.getBuffer().asDoubleBuffer();
             double[] out = new double[db.remaining()];
             db.get(out);
@@ -1049,7 +1055,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = (Buffer) sa.getBuffer();
+            buffer.rewind();
             DoubleBuffer fb = sa.getBuffer().asDoubleBuffer();
             fb.position(0);
             long[] shape = sa.getShape();
@@ -1071,7 +1078,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = (Buffer) sa.getBuffer();
+            buffer.rewind();
             DoubleBuffer db = sa.getBuffer().asDoubleBuffer();
             db.position(0);
             long[] shape = sa.getShape();
@@ -1095,7 +1103,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = sa.getBuffer();
+            buffer.rewind();
             DoubleBuffer db = sa.getBuffer().asDoubleBuffer();
             db.position(0);
             long[] shape = sa.getShape();
@@ -1121,7 +1130,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = sa.getBuffer();
+            buffer.rewind();
             DoubleBuffer db = sa.getBuffer().asDoubleBuffer();
             db.position(0);
             long[] shape = sa.getShape();
@@ -1149,7 +1159,8 @@ public class JavaNDArrayConverters {
         @Override
         protected  <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            Buffer buffer = sa.getBuffer();
+            buffer.rewind();
             ByteBuffer byteBuffer = sa.getBuffer().asReadOnlyBuffer();
             byte[] out = new byte[byteBuffer.remaining()];
             byteBuffer.get(out);
@@ -1167,9 +1178,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
-            ByteBuffer byteBuffer = sa.getBuffer().asReadOnlyBuffer();
-            byteBuffer.position(0);
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             long[] shape = sa.getShape();
             byte[][] out = new byte[(int) shape[0]][(int) shape[1]];
             for(byte[] f : out){
@@ -1189,9 +1199,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
-            ByteBuffer byteBuffer = sa.getBuffer().asReadOnlyBuffer();
-            byteBuffer.position(0);
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             long[] shape = sa.getShape();
             byte[][][] out = new byte[(int) shape[0]][(int) shape[1]][(int) shape[2]];
             for(byte[][] f : out){
@@ -1213,9 +1222,7 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
-            ByteBuffer byteBuffer = sa.getBuffer().asReadOnlyBuffer();
-            byteBuffer.position(0);
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
             long[] shape = sa.getShape();
             byte[][][][] out = new byte[(int) shape[0]][(int) shape[1]][(int) shape[2]][(int) shape[3]];
             for(byte[][][] f : out){
@@ -1239,9 +1246,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
-            ByteBuffer byteBuffer = sa.getBuffer().asReadOnlyBuffer();
-            byteBuffer.position(0);
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             long[] shape = sa.getShape();
             byte[][][][][] out = new byte[(int) shape[0]][(int) shape[1]][(int) shape[2]][(int) shape[3]][(int)shape[4]];
             for(byte[][][][] f : out){
@@ -1267,7 +1273,8 @@ public class JavaNDArrayConverters {
         @Override
         protected  <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             ShortBuffer sb = sa.getBuffer().asShortBuffer();
             short[] out = new short[sb.remaining()];
             sb.get(out);
@@ -1285,7 +1292,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             ShortBuffer sb = sa.getBuffer().asShortBuffer();
             sb.position(0);
             long[] shape = sa.getShape();
@@ -1307,7 +1315,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             ShortBuffer sb = sa.getBuffer().asShortBuffer();
             sb.position(0);
             long[] shape = sa.getShape();
@@ -1331,7 +1340,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             ShortBuffer sb = sa.getBuffer().asShortBuffer();
             sb.position(0);
             long[] shape = sa.getShape();
@@ -1357,7 +1367,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             ShortBuffer sb = sa.getBuffer().asShortBuffer();
             sb.position(0);
             long[] shape = sa.getShape();
@@ -1385,7 +1396,8 @@ public class JavaNDArrayConverters {
         @Override
         protected  <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             IntBuffer ib = sa.getBuffer().asIntBuffer();
             int[] out = new int[ib.remaining()];
             ib.get(out);
@@ -1403,7 +1415,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             IntBuffer ib = sa.getBuffer().asIntBuffer();
             ib.position(0);
             long[] shape = sa.getShape();
@@ -1425,7 +1438,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             IntBuffer ib = sa.getBuffer().asIntBuffer();
             ib.position(0);
             long[] shape = sa.getShape();
@@ -1449,7 +1463,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             IntBuffer ib = sa.getBuffer().asIntBuffer();
             ib.position(0);
             long[] shape = sa.getShape();
@@ -1475,7 +1490,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             IntBuffer ib = sa.getBuffer().asIntBuffer();
             ib.position(0);
             long[] shape = sa.getShape();
@@ -1503,7 +1519,8 @@ public class JavaNDArrayConverters {
         @Override
         protected  <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             LongBuffer lb = sa.getBuffer().asLongBuffer();
             long[] out = new long[lb.remaining()];
             lb.get(out);
@@ -1521,7 +1538,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             LongBuffer lb = sa.getBuffer().asLongBuffer();
             lb.position(0);
             long[] shape = sa.getShape();
@@ -1543,7 +1561,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             LongBuffer lb = sa.getBuffer().asLongBuffer();
             lb.position(0);
             long[] shape = sa.getShape();
@@ -1567,7 +1586,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             LongBuffer lb = sa.getBuffer().asLongBuffer();
             lb.position(0);
             long[] shape = sa.getShape();
@@ -1593,7 +1613,8 @@ public class JavaNDArrayConverters {
         @Override
         protected <T> T doConversion(NDArray from, Class<T> to){
             SerializedNDArray sa = (SerializedNDArray) from.get();
-            sa.getBuffer().rewind();
+            ByteBuffer byteBuffer = SerializedNDArray.resetSerializedNDArrayBuffer(sa);
+
             LongBuffer lb = sa.getBuffer().asLongBuffer();
             lb.position(0);
             long[] shape = sa.getShape();

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <micrometer.version>1.2.0</micrometer.version>
         <netty.version>4.1.48.Final</netty.version>
         <arrow.version>4.0.0</arrow.version>
-        <dl4j.version>1.0.0-M1</dl4j.version>
+        <dl4j.version>1.0.0-SNAPSHOT</dl4j.version>
         <datavec.version>${dl4j.version}</datavec.version>
         <nd4j.version>${dl4j.version}</nd4j.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Ensures compilation on java 11 by casting buffers to avoid NoSuchMethodError() on rewind() in java 11.